### PR TITLE
Use neutral styling for delete session menu items

### DIFF
--- a/src/components/SessionContextMenu.tsx
+++ b/src/components/SessionContextMenu.tsx
@@ -288,10 +288,7 @@ export function SessionContextMenu({
           <ContextMenu.Separator className={CTX_SEPARATOR_CLASS} />
 
           {/* Delete */}
-          <ContextMenu.Item
-            className={`${CTX_ITEM_CLASS} text-destructive focus:text-destructive`}
-            onSelect={onDelete}
-          >
+          <ContextMenu.Item className={CTX_ITEM_CLASS} onSelect={onDelete}>
             <Trash2 className="size-4" />
             <span>{t("sessionMenu.deleteSession")}</span>
           </ContextMenu.Item>

--- a/src/components/SidebarItemMenus.tsx
+++ b/src/components/SidebarItemMenus.tsx
@@ -233,7 +233,6 @@ export function SessionItemMenu({
           </>
         )}
         <DropdownMenuItem
-          variant="destructive"
           onClick={(event) => {
             event.stopPropagation();
             onDelete();


### PR DESCRIPTION
## Summary
- Remove destructive/red styling from the session context menu delete item
- Remove destructive variant from the session dropdown delete item
- Leave project remove menu items with neutral styling

## Verification
- `vp check` in the active workspace: formatting passed; existing warning remains in `claude-code-bridge.ts:1038` for `probe.close()` without `void/await`
- `vp check` in the clean PR worktree could not run because dependencies were not installed there (`@tailwindcss/vite`, `@vitejs/plugin-react`, `vite-plus`)