### PR TITLE
Fix appearance accent and contrast slider

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -21,7 +21,7 @@ function Slider({
 
   return (
     <SliderPrimitive.Root
-      className={cn("w-full", className)}
+      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
       data-slot="slider"
       defaultValue={defaultValue}
       value={value}
@@ -33,14 +33,14 @@ function Slider({
       thumbAlignment="edge"
       {...props}
     >
-      <SliderPrimitive.Control className="relative flex h-6 w-full touch-none items-center select-none data-disabled:opacity-50">
+      <SliderPrimitive.Control className="relative flex touch-none items-center select-none data-disabled:opacity-50 data-horizontal:h-6 data-horizontal:w-full data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
         <SliderPrimitive.Track
           data-slot="slider-track"
-          className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-foreground/15 select-none"
+          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1.5 data-horizontal:w-full data-vertical:h-full data-vertical:w-1.5"
         >
           <SliderPrimitive.Indicator
             data-slot="slider-range"
-            className="h-full bg-primary select-none"
+            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
           />
         </SliderPrimitive.Track>
         {Array.from({ length: _values.length }, (_, index) => (

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -21,7 +21,7 @@ function Slider({
 
   return (
     <SliderPrimitive.Root
-      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+      className={cn("w-full", className)}
       data-slot="slider"
       defaultValue={defaultValue}
       value={value}
@@ -33,21 +33,21 @@ function Slider({
       thumbAlignment="edge"
       {...props}
     >
-      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+      <SliderPrimitive.Control className="relative flex h-6 w-full touch-none items-center select-none data-disabled:opacity-50">
         <SliderPrimitive.Track
           data-slot="slider-track"
-          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
+          className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-foreground/15 select-none"
         >
           <SliderPrimitive.Indicator
             data-slot="slider-range"
-            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+            className="h-full bg-primary select-none"
           />
         </SliderPrimitive.Track>
         {Array.from({ length: _values.length }, (_, index) => (
           <SliderPrimitive.Thumb
             data-slot="slider-thumb"
             key={index}
-            className="relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
+            className="relative block size-4 shrink-0 rounded-full border-2 border-primary bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
           />
         ))}
       </SliderPrimitive.Control>

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -10,6 +10,12 @@ const DEFAULT_CONTRAST = 50;
 const DEFAULT_ACCENT_COLOR = "default";
 const DEFAULT_CODE_FONT_SIZE = 13;
 
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
 function getStoredMode(): ThemeMode {
   const stored = storageGet(STORAGE_KEYS.THEME);
   if (stored === "dark" || stored === "light" || stored === "system") return stored;
@@ -67,7 +73,7 @@ function applyContrast(contrast: number, theme: Theme) {
   }
 }
 
-function hexToRgb(hex: string) {
+function hexToRgb(hex: string): RGB {
   const normalized = hex.replace("#", "");
   const value = Number.parseInt(normalized, 16);
   return {
@@ -77,7 +83,7 @@ function hexToRgb(hex: string) {
   };
 }
 
-function getReadableForeground({ r, g, b }: ReturnType<typeof hexToRgb>) {
+function getReadableForeground({ r, g, b }: RGB) {
   const toLinear = (channel: number) => {
     const srgb = channel / 255;
     return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -77,17 +77,33 @@ function hexToRgb(hex: string) {
   };
 }
 
+function getReadableForeground({ r, g, b }: ReturnType<typeof hexToRgb>) {
+  const toLinear = (channel: number) => {
+    const srgb = channel / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  };
+  const luminance = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+  return luminance > 0.45 ? "oklch(0.145 0 0)" : "oklch(0.985 0 0)";
+}
+
 function applyAccentColor(color: string) {
   const root = document.documentElement;
+  const dynamicVars = [
+    "--dynamic-primary",
+    "--dynamic-primary-foreground",
+    "--dynamic-primary-rgb",
+  ];
+
   if (color === "default") {
-    // Remove custom primary → CSS fallback to original neutral values
-    root.style.removeProperty("--dynamic-primary");
-    root.style.removeProperty("--dynamic-primary-rgb");
-  } else {
-    const { r, g, b } = hexToRgb(color);
-    root.style.setProperty("--dynamic-primary", color);
-    root.style.setProperty("--dynamic-primary-rgb", `${r} ${g} ${b}`);
+    // Remove custom tokens → CSS falls back to theme-native neutral values.
+    for (const name of dynamicVars) root.style.removeProperty(name);
+    return;
   }
+
+  const rgb = hexToRgb(color);
+  root.style.setProperty("--dynamic-primary", color);
+  root.style.setProperty("--dynamic-primary-foreground", getReadableForeground(rgb));
+  root.style.setProperty("--dynamic-primary-rgb", `${rgb.r} ${rgb.g} ${rgb.b}`);
 }
 
 function applyCodeFontSize(size: number) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -135,7 +135,19 @@
   --card: oklch(var(--dynamic-card-l) 0 0);
   --popover: oklch(var(--dynamic-card-l) 0 0);
   --sidebar: oklch(var(--dynamic-bg-l) 0 0);
+  --primary: var(--dynamic-primary, oklch(0.205 0 0));
+  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.985 0 0));
+  --ring: var(--dynamic-primary, oklch(0.708 0 0));
   --sidebar-primary: var(--dynamic-primary, oklch(0.205 0 0));
+  --sidebar-ring: var(--dynamic-primary, oklch(0.708 0 0));
+}
+
+.dark {
+  --primary: var(--dynamic-primary, oklch(0.922 0 0));
+  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.205 0 0));
+  --ring: var(--dynamic-primary, oklch(0.556 0 0));
+  --sidebar-primary: var(--dynamic-primary, oklch(0.488 0.243 264.376));
+  --sidebar-ring: var(--dynamic-primary, oklch(0.556 0 0));
 }
 
 /*

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,14 +59,16 @@
 :root {
   --radius: 0.625rem;
   --code-font-size: 13px;
-  --background: oklch(1 0 0);
+  --dynamic-bg-l: 1;
+  --dynamic-card-l: 1;
+  --background: oklch(var(--dynamic-bg-l) 0 0);
   --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
+  --card: oklch(var(--dynamic-card-l) 0 0);
   --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
+  --popover: oklch(var(--dynamic-card-l) 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: var(--dynamic-primary, oklch(0.205 0 0));
+  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.985 0 0));
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -76,33 +78,33 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: var(--dynamic-primary, oklch(0.708 0 0));
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.985 0 0);
+  --sidebar: oklch(var(--dynamic-bg-l) 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary: var(--dynamic-primary, oklch(0.205 0 0));
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: var(--dynamic-primary, oklch(0.708 0 0));
 }
 
 .dark {
   --dynamic-bg-l: 0.145;
   --dynamic-card-l: 0.205;
-  --background: oklch(0.145 0 0);
+  --background: oklch(var(--dynamic-bg-l) 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(var(--dynamic-card-l) 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(var(--dynamic-card-l) 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: var(--dynamic-primary, oklch(0.922 0 0));
+  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.205 0 0));
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -112,7 +114,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: var(--dynamic-primary, oklch(0.556 0 0));
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -120,33 +122,11 @@
   --chart-5: oklch(0.269 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: var(--dynamic-primary, oklch(0.488 0.243 264.376));
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-}
-
-:root {
-  --dynamic-bg-l: 1;
-  --dynamic-card-l: 1;
-  --background: oklch(var(--dynamic-bg-l) 0 0);
-  --card: oklch(var(--dynamic-card-l) 0 0);
-  --popover: oklch(var(--dynamic-card-l) 0 0);
-  --sidebar: oklch(var(--dynamic-bg-l) 0 0);
-  --primary: var(--dynamic-primary, oklch(0.205 0 0));
-  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.985 0 0));
-  --ring: var(--dynamic-primary, oklch(0.708 0 0));
-  --sidebar-primary: var(--dynamic-primary, oklch(0.205 0 0));
-  --sidebar-ring: var(--dynamic-primary, oklch(0.708 0 0));
-}
-
-.dark {
-  --primary: var(--dynamic-primary, oklch(0.922 0 0));
-  --primary-foreground: var(--dynamic-primary-foreground, oklch(0.205 0 0));
-  --ring: var(--dynamic-primary, oklch(0.556 0 0));
-  --sidebar-primary: var(--dynamic-primary, oklch(0.488 0.243 264.376));
   --sidebar-ring: var(--dynamic-primary, oklch(0.556 0 0));
 }
 


### PR DESCRIPTION
## Summary
- apply selected accent color to primary/ring tokens so buttons, links, plugin UI, and session affordances inherit settings
- compute readable foreground color for custom accents
- fix Base UI slider track sizing so contrast bar is visible while keeping thumb white

## Test
- bunx tsc --noEmit