### PR TITLE
Fix language select display label

### DIFF
--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -187,6 +187,9 @@ function LanguageSetting() {
     void i18n.changeLanguage(value);
   };
 
+  const selectedLanguageLabel =
+    language === "auto" ? t("common.autoDetect") : t(`languages.${language}`);
+
   return (
     <div className="flex items-center justify-between gap-3 pt-3 border-t">
       <div className="flex items-center gap-2">
@@ -195,7 +198,7 @@ function LanguageSetting() {
       </div>
       <Select value={language} onValueChange={handleChange}>
         <SelectTrigger className="w-[180px] h-8">
-          <SelectValue placeholder={t("settings.general.language")} />
+          <SelectValue placeholder={t("settings.general.language")}>{selectedLanguageLabel}</SelectValue>
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="auto">{t("common.autoDetect")}</SelectItem>


### PR DESCRIPTION
## Summary
- show translated language labels in language select trigger instead of raw values like en/de
- keep auto-detect label visible when selected

## Test
- Not run: bun unavailable in environment (`bun: Befehl nicht gefunden`)