### PR TITLE
Fix settings sidebar active state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -471,6 +471,7 @@ function AppContent({ detachedProject }: { detachedProject?: string }) {
     <>
       <AppSidebar
         detachedProject={detachedProject}
+        highlightedSessionId={activeView === "chat" ? sessionActiveId : null}
         onOpenSettings={() => setActiveView("settings")}
         onOpenChat={() => setActiveView("chat")}
         settingsActive={activeView === "settings"}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -37,11 +37,13 @@ import { useSidebarModel } from "./sidebar/use-sidebar-model";
 
 export function AppSidebar({
   detachedProject,
+  highlightedSessionId,
   onOpenSettings,
   onOpenChat,
   settingsActive = false,
 }: {
   detachedProject?: string;
+  highlightedSessionId?: string | null;
   onOpenSettings: () => void;
   onOpenChat: () => void;
   settingsActive?: boolean;
@@ -82,6 +84,8 @@ export function AppSidebar({
     activeTargetDirectory,
   } = useSessionState();
 
+  const visibleActiveSessionId =
+    highlightedSessionId === undefined ? activeSessionId : highlightedSessionId;
   const activeSession = sessions.find((s) => s.id === activeSessionId);
   const activeSessionDirectory =
     activeSession?._projectDir ?? activeSession?.directory ?? activeTargetDirectory ?? null;
@@ -324,7 +328,7 @@ export function AppSidebar({
     <SessionRow
       key={session.id}
       session={session}
-      activeSessionId={activeSessionId}
+      activeSessionId={visibleActiveSessionId}
       busySessionIds={busySessionIds}
       unreadSessionIds={unreadSessionIds}
       queuedPrompts={queuedPrompts}
@@ -458,7 +462,7 @@ export function AppSidebar({
             directory={projectPopover.directory}
             top={projectPopover.top}
             sessions={popoverSessions}
-            activeSessionId={activeSessionId}
+            activeSessionId={visibleActiveSessionId}
             busySessionIds={busySessionIds}
             unreadSessionIds={unreadSessionIds}
             queuedPrompts={queuedPrompts}


### PR DESCRIPTION
## Summary
- hide the active session highlight while the settings view is open
- keep the underlying active session unchanged for returning to chat

## Verification
- Confirmed manually in the app that only Settings is highlighted in the sidebar while settings are open
- Ran `vp check src/App.tsx src/components/AppSidebar.tsx` successfully in the main worktree before isolating the PR branch

Note: running `vp check` in the temporary isolated worktree was blocked because dependencies are not installed there.