### PR TITLE
Fix session scroll restoration

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -453,6 +453,7 @@ export function MessageList({ detachedProject: _detachedProject }: { detachedPro
 
   return (
     <VirtualMessageScroller
+      key={activeSessionId}
       scrollKey={activeSessionId}
       scrollSnapshotsRef={scrollSnapshotsRef}
       messages={visibleMessages}

--- a/src/components/message-list/VirtualMessageScroller.tsx
+++ b/src/components/message-list/VirtualMessageScroller.tsx
@@ -96,22 +96,29 @@ export function VirtualMessageScroller({
     useAnimationFrameWithResizeObserver: true,
   });
 
+  const writeScrollSnapshot = useCallback(
+    (sessionId: string) => {
+      const scrollEl = scrollRef.current;
+      if (!scrollEl) return;
+      const first = virtualizer.getVirtualItems()[0];
+      const pinnedToBottom = isNearBottom(scrollEl);
+      pinnedToBottomRef.current = pinnedToBottom;
+      scrollSnapshotsRef.current.set(sessionId, {
+        anchorKey: first ? String(first.key) : null,
+        offsetFromViewportTop: first ? first.start - scrollEl.scrollTop : 0,
+        scrollTop: scrollEl.scrollTop,
+        distanceFromBottom: distanceFromBottom(scrollEl),
+        pinnedToBottom,
+        updatedAt: Date.now(),
+      });
+    },
+    [scrollSnapshotsRef, virtualizer],
+  );
+
   const captureScrollSnapshot = useCallback(() => {
     if (!scrollKey) return;
-    const scrollEl = scrollRef.current;
-    if (!scrollEl) return;
-    const first = virtualizer.getVirtualItems()[0];
-    const pinnedToBottom = isNearBottom(scrollEl);
-    pinnedToBottomRef.current = pinnedToBottom;
-    scrollSnapshotsRef.current.set(scrollKey, {
-      anchorKey: first ? String(first.key) : null,
-      offsetFromViewportTop: first ? first.start - scrollEl.scrollTop : 0,
-      scrollTop: scrollEl.scrollTop,
-      distanceFromBottom: distanceFromBottom(scrollEl),
-      pinnedToBottom,
-      updatedAt: Date.now(),
-    });
-  }, [scrollKey, scrollSnapshotsRef, virtualizer]);
+    writeScrollSnapshot(scrollKey);
+  }, [scrollKey, writeScrollSnapshot]);
 
   const scheduleScrollSnapshot = useCallback(() => {
     if (snapshotFrameRef.current != null) return;
@@ -239,6 +246,18 @@ export function VirtualMessageScroller({
   );
 
   useLayoutEffect(() => {
+    const sessionId = scrollKey;
+    return () => {
+      if (snapshotFrameRef.current != null) {
+        cancelAnimationFrame(snapshotFrameRef.current);
+        snapshotFrameRef.current = null;
+      }
+      if (!sessionId) return;
+      writeScrollSnapshot(sessionId);
+    };
+  }, [scrollKey, writeScrollSnapshot]);
+
+  useLayoutEffect(() => {
     restorePaginationAnchor();
   }, [restorePaginationAnchor, messages.length]);
 
@@ -257,29 +276,6 @@ export function VirtualMessageScroller({
     lastMessageKeyRef.current = keys.at(-1) ?? null;
     restoredScrollKeyRef.current = scrollKey;
   }, [keys, messages.length, restoreScrollSnapshot, scrollKey, scrollSnapshotsRef, scrollToLatest]);
-
-  useEffect(() => {
-    const sessionId = scrollKey;
-    return () => {
-      if (snapshotFrameRef.current != null) {
-        cancelAnimationFrame(snapshotFrameRef.current);
-        snapshotFrameRef.current = null;
-      }
-      if (!sessionId) return;
-      const scrollEl = scrollRef.current;
-      if (!scrollEl) return;
-      const first = virtualizer.getVirtualItems()[0];
-      const pinnedToBottom = isNearBottom(scrollEl);
-      scrollSnapshotsRef.current.set(sessionId, {
-        anchorKey: first ? String(first.key) : null,
-        offsetFromViewportTop: first ? first.start - scrollEl.scrollTop : 0,
-        scrollTop: scrollEl.scrollTop,
-        distanceFromBottom: distanceFromBottom(scrollEl),
-        pinnedToBottom,
-        updatedAt: Date.now(),
-      });
-    };
-  }, [scrollKey]);
 
   useEffect(() => {
     const lastKey = keys.at(-1) ?? null;


### PR DESCRIPTION
## Summary
- remount the virtual message scroller per active session while preserving the shared snapshot map
- write scroll snapshots through a single helper
- save the outgoing session snapshot in a layout cleanup before restoring the next session

## Verification
- vp check src/components/message-list/VirtualMessageScroller.tsx src/components/MessageList.tsx
- manually verified switching sessions restores the previous scroll position