### PR TITLE
Fix sidebar session harness ordering

### DIFF
--- a/BetterSDK/src/sessions.ts
+++ b/BetterSDK/src/sessions.ts
@@ -53,6 +53,6 @@ export async function forkSession(sessionId: string, opts: { dir?: string; upToM
 }
 
 function timestamp(m: any): number | undefined { const t = m?.timestamp ?? m?.created_at ?? m?.time; const n = typeof t === "string" ? Date.parse(t) : typeof t === "number" ? t : NaN; return Number.isFinite(n) ? n : undefined; }
-function contentText(c: unknown): string { if (typeof c === "string") return c; if (Array.isArray(c)) return c.map((x: any) => x?.text ?? "").join(""); return ""; }
+function contentText(c: unknown): string { const text = typeof c === "string" ? c : Array.isArray(c) ? c.map((x: any) => x?.text ?? "").join("") : ""; return cleanSessionTitle(text); }
+function cleanSessionTitle(title: string): string { const trimmed = title.trim(); if (!trimmed) return ""; return trimmed.replace(/^(?:human|assistant|user)\s*:\s*/i, "").trim() || trimmed; }
 export function projectHash(dir: string): string { return createHash("sha1").update(dir).digest("hex"); }
-

--- a/server/services/runtime-session-mapper.ts
+++ b/server/services/runtime-session-mapper.ts
@@ -1,5 +1,6 @@
 import type { HarnessId } from "../../src/agents/index.ts";
 import { rawSessionIdForHarness } from "../../src/lib/session-identity.ts";
+import { cleanSessionTitle } from "../../src/lib/session-title.ts";
 import type { SessionService } from "./session-service.ts";
 import type { CreateSessionInput, SessionRecord } from "./session-types.ts";
 
@@ -27,7 +28,7 @@ function extractRuntimeSessionTitle(session: unknown): string {
   if (!isPlainObject(session)) return "Untitled";
   const candidates = [session.title, session.name, session.slug, session.id];
   for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+    if (typeof candidate === "string" && candidate.trim()) return cleanSessionTitle(candidate);
   }
   return "Untitled";
 }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useHomeDir } from "@/hooks/use-home-dir";
+import { useCurrentHarnessId } from "@/hooks/use-agent-backend";
 import { useActions, useConnectionState, useSessionState } from "@/hooks/use-agent-state";
 import { useOpenGuiClient } from "@/protocol/provider";
 import { useOutsideClick } from "@/hooks/use-outside-click";
@@ -47,6 +48,7 @@ export function AppSidebar({
   settingsActive?: boolean;
 }) {
   const client = useOpenGuiClient();
+  const preferredHarnessId = useCurrentHarnessId();
   const { t } = useTranslation();
   const { state: sidebarState, isMobile, setOpen: setSidebarOpen, setOpenMobile } = useSidebar();
   const {
@@ -160,6 +162,7 @@ export function AppSidebar({
     connections,
     detachedProject,
     defaultChatDirectory,
+    preferredHarnessId,
     searchQuery,
     untitledLabel: t("sidebar.untitled"),
   });

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -1,6 +1,7 @@
 import { BadgeQuestionMark, GitBranch, MessageSquare, ShieldAlert } from "lucide-react";
 import { HARNESS_LABELS } from "@/agents";
 import type { Session } from "@/hooks/agent-state-types";
+import { getSessionHarnessId } from "@/hooks/agent-session-utils";
 import type {
   SessionColor,
   SessionMetaMap,
@@ -14,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { getColorBorderClass, SessionContextMenu } from "@/components/SessionContextMenu";
 import { SessionItemMenu } from "@/components/SidebarItemMenus";
+import { cleanSessionTitle } from "@/lib/session-title";
 
 export function SessionRow({
   session,
@@ -91,6 +93,8 @@ export function SessionRow({
   const tags = meta?.tags ?? [];
   const isPinned = !!meta?.pinnedAt;
   const isNaming = namingSessionIds.has(session.id);
+  const harnessId = getSessionHarnessId(session);
+  const displayTitle = cleanSessionTitle(session.title) || untitledLabel;
   const placement = getSessionPlacementInfo(
     session,
     worktreeParents,
@@ -139,7 +143,7 @@ export function SessionRow({
             isNaming
               ? undefined
               : {
-                  children: session.title || untitledLabel,
+                  children: displayTitle,
                   side: "right",
                   align: "center",
                   hidden: editingSessionId === session.id || isNaming,
@@ -214,12 +218,12 @@ export function SessionRow({
                   startEditing(session.id, session.title || "");
                 }}
               >
-                {session.title || untitledLabel}
+                {displayTitle}
               </span>
             )}
-            {session._harnessId && (
+            {harnessId && (
               <span className="shrink-0 rounded-full bg-muted px-1.5 py-0 text-[9px] font-medium text-muted-foreground">
-                {HARNESS_LABELS[session._harnessId]}
+                {HARNESS_LABELS[harnessId]}
               </span>
             )}
             {worktreeBranch && (

--- a/src/components/sidebar/use-sidebar-model.test.ts
+++ b/src/components/sidebar/use-sidebar-model.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import type { HarnessId } from "@/agents";
+import type { Session } from "@/hooks/agent-state-types";
+import { sortSessionsForSidebar } from "./use-sidebar-model";
+
+function session(id: string, harnessId: HarnessId, updated: number): Session {
+  return {
+    id,
+    title: id,
+    directory: "/repo",
+    _projectDir: "/repo",
+    _workspaceId: "workspace-1",
+    _harnessId: harnessId,
+    time: { created: updated, updated },
+  } as Session;
+}
+
+describe("sortSessionsForSidebar", () => {
+  test("keeps preferred Harness sessions above newer sessions from other Harnesses", () => {
+    const sorted = sortSessionsForSidebar(
+      [session("claude-new", "claude-code", 20), session("open-old", "opencode", 10)],
+      {},
+      "opencode",
+    );
+
+    expect(sorted.map((item) => item.id)).toEqual(["open-old", "claude-new"]);
+  });
+
+  test("sorts by newest update inside the same Harness", () => {
+    const sorted = sortSessionsForSidebar(
+      [session("open-old", "opencode", 10), session("open-new", "opencode", 20)],
+      {},
+      "opencode",
+    );
+
+    expect(sorted.map((item) => item.id)).toEqual(["open-new", "open-old"]);
+  });
+});

--- a/src/components/sidebar/use-sidebar-model.ts
+++ b/src/components/sidebar/use-sidebar-model.ts
@@ -13,7 +13,38 @@ import {
 } from "@/lib/worktree-placement";
 import { getProjectName, normalizeProjectPath } from "@/lib/utils";
 import type { ConnectionStatus, Workspace } from "@/types/electron";
-import { parseProjectKey } from "@/hooks/agent-session-utils";
+import { getSessionHarnessId, parseProjectKey } from "@/hooks/agent-session-utils";
+import type { HarnessId } from "@/agents";
+
+function getSidebarSessionSortTime(session: Session, sessionMeta: SessionMetaMap) {
+  const meta = sessionMeta[session.id];
+  if (meta?.detachedFromProject && typeof meta.detachedFromProjectAt === "number") {
+    return meta.detachedFromProjectAt;
+  }
+  if (meta?.assignedProjectDir && typeof meta.assignedProjectMovedAt === "number") {
+    return meta.assignedProjectMovedAt;
+  }
+  return session.time.updated ?? session.time.created ?? 0;
+}
+
+export function sortSessionsForSidebar(
+  items: Session[],
+  sessionMeta: SessionMetaMap,
+  preferredHarnessId?: HarnessId | null,
+) {
+  return [...items].sort((a, b) => {
+    if (preferredHarnessId) {
+      const aPreferred = getSessionHarnessId(a) === preferredHarnessId;
+      const bPreferred = getSessionHarnessId(b) === preferredHarnessId;
+      if (aPreferred !== bPreferred) return aPreferred ? -1 : 1;
+    }
+
+    const byUpdated =
+      getSidebarSessionSortTime(b, sessionMeta) - getSidebarSessionSortTime(a, sessionMeta);
+    if (byUpdated !== 0) return byUpdated;
+    return b.id.localeCompare(a.id);
+  });
+}
 
 export function useSidebarModel({
   sessions,
@@ -24,6 +55,7 @@ export function useSidebarModel({
   connections,
   detachedProject,
   defaultChatDirectory,
+  preferredHarnessId,
   searchQuery,
   untitledLabel,
 }: {
@@ -35,6 +67,7 @@ export function useSidebarModel({
   connections: Record<string, ConnectionStatus>;
   detachedProject?: string;
   defaultChatDirectory?: string | null;
+  preferredHarnessId?: HarnessId | null;
   searchQuery: string;
   untitledLabel: string;
 }) {
@@ -62,24 +95,9 @@ export function useSidebarModel({
     [defaultChatDirectory],
   );
 
-  const sortSessionsForSidebar = useCallback(
-    (items: Session[]) =>
-      [...items].sort((a, b) => {
-        const aMeta = sessionMeta[a.id];
-        const bMeta = sessionMeta[b.id];
-        const aTime =
-          aMeta?.assignedProjectDir && typeof aMeta.assignedProjectMovedAt === "number"
-            ? aMeta.assignedProjectMovedAt
-            : (a.time.updated ?? a.time.created ?? 0);
-        const bTime =
-          bMeta?.assignedProjectDir && typeof bMeta.assignedProjectMovedAt === "number"
-            ? bMeta.assignedProjectMovedAt
-            : (b.time.updated ?? b.time.created ?? 0);
-        const byUpdated = bTime - aTime;
-        if (byUpdated !== 0) return byUpdated;
-        return b.id.localeCompare(a.id);
-      }),
-    [sessionMeta],
+  const sortSidebarSessions = useCallback(
+    (items: Session[]) => sortSessionsForSidebar(items, sessionMeta, preferredHarnessId),
+    [preferredHarnessId, sessionMeta],
   );
 
   const projectGroups = useMemo(() => {
@@ -151,7 +169,7 @@ export function useSidebarModel({
     return new Map(
       Array.from(groups, ([directory, dirSessions]) => [
         directory,
-        sortSessionsForSidebar(dirSessions),
+        sortSidebarSessions(dirSessions),
       ]),
     );
   }, [
@@ -162,12 +180,12 @@ export function useSidebarModel({
     activeWorkspace,
     availableProjectDirectories,
     sessionMeta,
-    sortSessionsForSidebar,
+    sortSidebarSessions,
   ]);
 
   const chatSessions = useMemo(
     () =>
-      sortSessionsForSidebar(
+      sortSidebarSessions(
         sessions.filter(
           (session) =>
             !session.parentID &&
@@ -175,7 +193,7 @@ export function useSidebarModel({
             isDefaultChatDirectory(session._projectDir ?? session.directory),
         ),
       ),
-    [sessions, isDefaultChatDirectory, sessionMeta, sortSessionsForSidebar],
+    [sessions, isDefaultChatDirectory, sessionMeta, sortSidebarSessions],
   );
 
   const filteredChatSessions = useMemo(() => {

--- a/src/hooks/agent-session-utils.ts
+++ b/src/hooks/agent-session-utils.ts
@@ -47,7 +47,9 @@ export function getSessionProjectTarget(session: Session | undefined | null): Pr
 }
 
 export function getSessionHarnessId(session: Session | undefined | null): HarnessId | null {
-  return session?._harnessId ?? getHarnessIdFromSessionId(session?.id) ?? null;
+  return (
+    session?._harnessId ?? session?._backendId ?? getHarnessIdFromSessionId(session?.id) ?? null
+  );
 }
 
 export function getSessionSelectedModel(session: Session | undefined | null): SelectedModel | null {

--- a/src/hooks/agent-state-types.ts
+++ b/src/hooks/agent-state-types.ts
@@ -34,6 +34,8 @@ export type Session = BaseSession & {
   _projectDir?: string;
   _workspaceId?: string;
   _harnessId?: HarnessId;
+  /** Legacy field persisted by versions before the Harness migration. */
+  _backendId?: HarnessId;
   _rawId?: string;
 };
 

--- a/src/lib/__tests__/session-identity.test.ts
+++ b/src/lib/__tests__/session-identity.test.ts
@@ -34,6 +34,13 @@ describe("session identity", () => {
     );
   });
 
+  test("keeps legacy backend-tagged Sessions identifiable after Harness migration", () => {
+    expect(harnessSessionIdentity({ id: "raw-1", _backendId: "opencode" })).toBe("opencode:raw-1");
+    expect(
+      sameHarnessSessionIdentity({ id: "raw-1", _backendId: "opencode" }, { id: "opencode:raw-1" }),
+    ).toBe(true);
+  });
+
   test("builds storage mapping keys in one place", () => {
     expect(scopedRawSessionKey({ projectId: "project-1", harnessId: "pi", rawId: "raw-1" })).toBe(
       "project-1::pi::raw-1",

--- a/src/lib/__tests__/session-title.test.ts
+++ b/src/lib/__tests__/session-title.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import { cleanSessionTitle } from "@/lib/session-title";
+
+describe("cleanSessionTitle", () => {
+  test("removes raw chat role prefixes from imported Session titles", () => {
+    expect(cleanSessionTitle("Human: verbinde die Datenbank")).toBe("verbinde die Datenbank");
+    expect(cleanSessionTitle("Assistant: Komponente prüfen")).toBe("Komponente prüfen");
+    expect(cleanSessionTitle("User: fix sidebar sessions")).toBe("fix sidebar sessions");
+  });
+
+  test("keeps meaningful titles untouched", () => {
+    expect(cleanSessionTitle("OpenCode Sidebar Fix")).toBe("OpenCode Sidebar Fix");
+  });
+});

--- a/src/lib/session-identity.ts
+++ b/src/lib/session-identity.ts
@@ -8,6 +8,8 @@ export type SessionIdentityScope = {
 export type SessionIdentityLike = {
   id: string;
   _harnessId?: HarnessId;
+  /** Legacy name used by releases before the Harness terminology migration. */
+  _backendId?: HarnessId;
   _rawId?: string;
 };
 
@@ -34,7 +36,8 @@ export function rawSessionIdForHarness(sessionId: string, harnessId: HarnessId):
 }
 
 export function harnessSessionIdentity(session: SessionIdentityLike): string {
-  const harnessId = session._harnessId ?? parseFrontendSessionId(session.id)?.harnessId;
+  const harnessId =
+    session._harnessId ?? session._backendId ?? parseFrontendSessionId(session.id)?.harnessId;
   if (!harnessId) return session.id;
   const rawId = session._rawId ?? rawSessionIdForHarness(session.id, harnessId);
   return composeFrontendSessionId(harnessId, rawId);

--- a/src/lib/session-title.ts
+++ b/src/lib/session-title.ts
@@ -1,0 +1,8 @@
+const ROLE_PREFIX_PATTERN = /^(?:human|assistant|user)\s*:\s*/i;
+
+export function cleanSessionTitle(title: string | null | undefined): string {
+  const trimmed = String(title ?? "").trim();
+  if (!trimmed) return "";
+
+  return trimmed.replace(ROLE_PREFIX_PATTERN, "").trim() || trimmed;
+}


### PR DESCRIPTION
## Summary
- keep preferred harness sessions first in sidebar project groups while preserving newest-first order within a harness
- clean imported session titles by removing raw Human/Assistant/User prefixes
- support legacy _backendId session metadata after the harness migration

## Tests
- vp test src/components/sidebar/use-sidebar-model.test.ts src/lib/__tests__/session-identity.test.ts src/lib/__tests__/session-title.test.ts src/hooks/agent-reducer.test.ts

## Notes
- Full vp check still fails on existing baseline formatting issues outside this fix.