### PR TITLE
Remove sidebar rail toggle

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -6,7 +6,6 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarRail,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useHomeDir } from "@/hooks/use-home-dir";
@@ -555,8 +554,6 @@ export function AppSidebar({
           </div>
         </SidebarFooter>
       )}
-
-      <SidebarRail />
 
       <ProjectPathDialog />
 


### PR DESCRIPTION
## Summary
- remove the sidebar edge rail toggle so the resize-like hover target no longer appears
- keep the title-bar sidebar toggle intact for manual collapsing

## Verification
- git diff --check
- vp check src/components/AppSidebar.tsx could not run in the clean worktree because dependencies are not installed there; the same affected files were checked successfully in the original workspace before creating this isolated branch