### PR TITLE
Fix moved session project context

### DIFF
--- a/opencode-bridge.ts
+++ b/opencode-bridge.ts
@@ -222,13 +222,17 @@ function tagOpenCodeSession(session, dir, workspaceId) {
   if (!session) return session;
   const rawId = toRawSessionId(session.id);
   const id = toFrontendSessionId(rawId);
+  const sessionDirectory =
+    typeof session.directory === "string" && session.directory.trim()
+      ? session.directory.trim()
+      : null;
   return {
     ...session,
     id,
     slug: session.slug ? toFrontendSessionId(session.slug) : id,
     _harnessId: "opencode",
     _rawId: rawId,
-    _projectDir: dir ?? session._projectDir ?? session.directory,
+    _projectDir: session._projectDir ?? sessionDirectory ?? dir,
     _workspaceId: workspaceId ?? session._workspaceId,
   };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ function AppContent({
     isBusy,
     isLoadingMessages,
     activeTargetDirectory,
+    sessionMeta,
   } = useSessionState();
   const { messages } = useMessages();
   const { providers, selectedModel, providerDefaults } = useModelState();
@@ -100,6 +101,7 @@ function AppContent({
     sessions,
     activeSessionId,
     activeTargetDirectory,
+    sessionMeta,
     connections,
     defaultChatDirectory,
   });

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Sidebar, SidebarContent, useSidebar } from "@/components/ui/sidebar";
+import {
+  createSessionProjectMoveMeta,
+  getEffectiveSessionDirectory,
+} from "@/hooks/agent-session-utils";
 import { useHomeDir } from "@/hooks/use-home-dir";
 import { useCurrentHarnessId } from "@/hooks/use-agent-backend";
 import { useActions, useConnectionState, useSessionState } from "@/hooks/use-agent-state";
@@ -76,9 +81,6 @@ export function AppSidebar({
 
   const visibleActiveSessionId =
     highlightedSessionId === undefined ? activeSessionId : highlightedSessionId;
-  const activeSession = sessions.find((s) => s.id === activeSessionId);
-  const activeSessionDirectory =
-    activeSession?._projectDir ?? activeSession?.directory ?? activeTargetDirectory ?? null;
   const {
     connections,
     worktreeParents,
@@ -119,6 +121,82 @@ export function AppSidebar({
       }),
     [],
   );
+  const [optimisticSessionMeta, setOptimisticSessionMeta] = useState<typeof sessionMeta>({});
+  const mergedSessionMeta = useMemo(() => {
+    if (Object.keys(optimisticSessionMeta).length === 0) return sessionMeta;
+    const next = { ...sessionMeta };
+    for (const [sessionId, meta] of Object.entries(optimisticSessionMeta)) {
+      next[sessionId] = { ...next[sessionId], ...meta };
+    }
+    return next;
+  }, [optimisticSessionMeta, sessionMeta]);
+  const activeSession = sessions.find((s) => s.id === activeSessionId);
+  const activeSessionDirectory =
+    getEffectiveSessionDirectory(
+      activeSession,
+      activeSessionId ? mergedSessionMeta[activeSessionId] : undefined,
+    ) ||
+    activeTargetDirectory ||
+    null;
+
+  useEffect(() => {
+    if (Object.keys(optimisticSessionMeta).length === 0) return;
+    setOptimisticSessionMeta((current) => {
+      let changed = false;
+      const next = { ...current };
+      for (const [sessionId, optimisticMeta] of Object.entries(current)) {
+        const committedMeta = sessionMeta[sessionId];
+        if (
+          committedMeta?.originMode === optimisticMeta.originMode &&
+          normalizeProjectPath(committedMeta?.assignedProjectDir ?? "") ===
+            normalizeProjectPath(optimisticMeta.assignedProjectDir ?? "") &&
+          committedMeta?.detachedFromProject === optimisticMeta.detachedFromProject
+        ) {
+          delete next[sessionId];
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [optimisticSessionMeta, sessionMeta]);
+
+  const moveSessionToProjectOptimistic = useCallback(
+    async (sessionId: string, directory: string) => {
+      const targetDirectory = normalizeProjectPath(directory);
+      const sourceSession = sessions.find((session) => session.id === sessionId);
+      const sourceDirectory = normalizeProjectPath(
+        (sourceSession?._projectDir ?? sourceSession?.directory) || "",
+      );
+      if (targetDirectory && sourceDirectory) {
+        const meta = createSessionProjectMoveMeta(
+          sourceSession,
+          mergedSessionMeta[sessionId],
+          targetDirectory,
+        );
+        if (!meta) return;
+        flushSync(() => {
+          setOptimisticSessionMeta((current) => ({
+            ...current,
+            [sessionId]: {
+              ...current[sessionId],
+              ...meta,
+            },
+          }));
+        });
+      }
+      try {
+        await moveSessionToProject(sessionId, directory);
+      } catch (error) {
+        setOptimisticSessionMeta((current) => {
+          const { [sessionId]: _removed, ...rest } = current;
+          return rest;
+        });
+        throw error;
+      }
+    },
+    [mergedSessionMeta, moveSessionToProject, sessions],
+  );
+
   const {
     hasActiveSearch,
     availableProjectDirectories,
@@ -128,7 +206,7 @@ export function AppSidebar({
     projectSessionsByDirectory,
   } = useSidebarModel({
     sessions,
-    sessionMeta,
+    sessionMeta: mergedSessionMeta,
     projectMeta,
     worktreeParents,
     activeWorkspace,
@@ -289,7 +367,7 @@ export function AppSidebar({
     isGitRepo,
     isLocalWorkspace,
     knownWorktrees,
-    moveSessionToProject,
+    moveSessionToProject: moveSessionToProjectOptimistic,
     namingSessionIds,
     pendingPermissions,
     pendingQuestions,
@@ -301,7 +379,7 @@ export function AppSidebar({
     removeSessionFromProject,
     revealSessionInProject,
     selectSession,
-    sessionMeta,
+    sessionMeta: mergedSessionMeta,
     setActiveTarget,
     setEditValue,
     setMergeInfo,
@@ -355,7 +433,7 @@ export function AppSidebar({
           hasMoreChats={hasMoreChats}
           canShowLessChats={canShowLessChats}
           worktreeParents={worktreeParents}
-          sessionMeta={sessionMeta}
+          sessionMeta={mergedSessionMeta}
           labels={{
             pinned: t("sidebar.pinned"),
             chats: t("sidebar.chats"),

--- a/src/components/sidebar/use-sidebar-model.test.ts
+++ b/src/components/sidebar/use-sidebar-model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
 import type { HarnessId } from "@/agents";
 import type { Session } from "@/hooks/agent-state-types";
-import { sortSessionsForSidebar } from "./use-sidebar-model";
+import { shouldShowSessionInChatList, sortSessionsForSidebar } from "./use-sidebar-model";
 
 function session(id: string, harnessId: HarnessId, updated: number): Session {
   return {
@@ -34,5 +34,47 @@ describe("sortSessionsForSidebar", () => {
     );
 
     expect(sorted.map((item) => item.id)).toEqual(["open-new", "open-old"]);
+  });
+});
+
+describe("shouldShowSessionInChatList", () => {
+  test("hides default-chat sessions after moving them into a project", () => {
+    const item = session("chat", "opencode", 20);
+    item.directory = "/home/tobias/Dokumente";
+    item._projectDir = "/home/tobias/Dokumente";
+
+    expect(
+      shouldShowSessionInChatList({
+        session: item,
+        meta: { assignedProjectDir: "/home/tobias/Dokumente/Jutta Kürzl" },
+        isDefaultChatDirectory: (directory) => directory === "/home/tobias/Dokumente",
+      }),
+    ).toBe(false);
+  });
+
+  test("hides project-origin sessions even when assignment is same-directory", () => {
+    const item = session("same-dir", "opencode", 20);
+    item.directory = "/home/tobias/Dokumente/Jutta Kürzl";
+    item._projectDir = "/home/tobias/Dokumente/Jutta Kürzl";
+
+    expect(
+      shouldShowSessionInChatList({
+        session: item,
+        meta: { originMode: "project", assignedProjectDir: null },
+        isDefaultChatDirectory: (directory) => directory === "/home/tobias/Dokumente/Jutta Kürzl",
+      }),
+    ).toBe(false);
+  });
+
+  test("still shows explicitly detached project sessions in Chats", () => {
+    const item = session("detached", "opencode", 20);
+
+    expect(
+      shouldShowSessionInChatList({
+        session: item,
+        meta: { assignedProjectDir: "/other", detachedFromProject: true },
+        isDefaultChatDirectory: () => false,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/components/sidebar/use-sidebar-model.ts
+++ b/src/components/sidebar/use-sidebar-model.ts
@@ -27,6 +27,22 @@ function getSidebarSessionSortTime(session: Session, sessionMeta: SessionMetaMap
   return session.time.updated ?? session.time.created ?? 0;
 }
 
+export function shouldShowSessionInChatList({
+  session,
+  meta,
+  isDefaultChatDirectory,
+}: {
+  session: Session;
+  meta: SessionMetaMap[string] | undefined;
+  isDefaultChatDirectory: (directory?: string | null) => boolean;
+}) {
+  if (session.parentID || meta?.movedToSessionId) return false;
+  if (meta?.detachedFromProject === true) return true;
+  if (meta?.originMode === "project") return false;
+  if (normalizeProjectPath(meta?.assignedProjectDir ?? "")) return false;
+  return isDefaultChatDirectory(session._projectDir ?? session.directory);
+}
+
 export function sortSessionsForSidebar(
   items: Session[],
   sessionMeta: SessionMetaMap,
@@ -113,7 +129,14 @@ export function useSidebarModel({
     const rootOpenDirectories = openDirectories.filter(
       (dir) => !shouldHideTopLevelProjectDirectory(dir, worktreeParents),
     );
-    const projectDirectorySet = new Set([...rootOpenDirectories, ...visibleProjectDirectorySet]);
+    const workspaceProjects = (activeWorkspace?.projects ?? [])
+      .map((dir) => normalizeProjectPath(dir))
+      .filter(Boolean);
+    const projectDirectorySet = new Set([
+      ...rootOpenDirectories,
+      ...workspaceProjects,
+      ...visibleProjectDirectorySet,
+    ]);
     const normalizedDetachedProject = normalizeProjectPath(detachedProject ?? "");
     const orderedRootDirectories = detachedProject
       ? rootOpenDirectories.filter((dir) => dir === normalizedDetachedProject)
@@ -187,12 +210,12 @@ export function useSidebarModel({
   const chatSessions = useMemo(
     () =>
       sortSidebarSessions(
-        sessions.filter(
-          (session) =>
-            !session.parentID &&
-            !sessionMeta[session.id]?.movedToSessionId &&
-            (sessionMeta[session.id]?.detachedFromProject === true ||
-              isDefaultChatDirectory(session._projectDir ?? session.directory)),
+        sessions.filter((session) =>
+          shouldShowSessionInChatList({
+            session,
+            meta: sessionMeta[session.id],
+            isDefaultChatDirectory,
+          }),
         ),
       ),
     [sessions, isDefaultChatDirectory, sessionMeta, sortSidebarSessions],

--- a/src/features/session/useChatSessionSurface.ts
+++ b/src/features/session/useChatSessionSurface.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { useConnectionState, useSessionState } from "@/hooks/use-agent-state";
 import { parseProjectKey } from "@/hooks/agent-session-utils";
+import { getEffectiveSessionDirectory } from "@/hooks/agent-session-utils";
 import { getChatSurfaceState, hasProjectConnectedPrompt } from "@/lib/chat-surface";
 import { normalizeProjectPath } from "@/lib/utils";
 
@@ -11,6 +12,7 @@ interface UseChatSessionSurfaceParams {
   sessions: SessionState["sessions"];
   activeSessionId: SessionState["activeSessionId"];
   activeTargetDirectory: SessionState["activeTargetDirectory"];
+  sessionMeta: SessionState["sessionMeta"];
   connections: ConnectionState["connections"];
   defaultChatDirectory: ConnectionState["defaultChatDirectory"];
 }
@@ -19,6 +21,7 @@ export function useChatSessionSurface({
   sessions,
   activeSessionId,
   activeTargetDirectory,
+  sessionMeta,
   connections,
   defaultChatDirectory,
 }: UseChatSessionSurfaceParams) {
@@ -28,7 +31,12 @@ export function useChatSessionSurface({
   );
 
   const activeSessionDirectory =
-    activeSession?._projectDir ?? activeSession?.directory ?? activeTargetDirectory ?? null;
+    getEffectiveSessionDirectory(
+      activeSession,
+      activeSessionId ? sessionMeta[activeSessionId] : undefined,
+    ) ||
+    activeTargetDirectory ||
+    null;
 
   const connectedTargetDirectories = useMemo(
     () =>

--- a/src/hooks/agent-directory-change-notice.test.ts
+++ b/src/hooks/agent-directory-change-notice.test.ts
@@ -31,4 +31,20 @@ describe("planDirectoryChangePrompt", () => {
       hideSystemAppendBlocks: true,
     });
   });
+
+  test("uses the backend session directory as target when moving back to the original project", () => {
+    const plan = planDirectoryChangePrompt({
+      text: "Where are you?",
+      session: { id: "session-1", directory: "/original/" } as never,
+      meta: {
+        assignedProjectDir: null,
+        assignedProjectSourceDir: "/previous-target/",
+        pendingDirectoryChangeNotice: true,
+      },
+    });
+
+    expect(plan.text).toContain("`/previous-target`");
+    expect(plan.text).toContain("`/original`");
+    expect(plan.text.endsWith("\n\nWhere are you?")).toBe(true);
+  });
 });

--- a/src/hooks/agent-directory-change-notice.ts
+++ b/src/hooks/agent-directory-change-notice.ts
@@ -12,16 +12,18 @@ export function planDirectoryChangePrompt(input: {
   session?: Session;
   meta?: SessionMeta;
 }): DirectoryChangePromptPlan {
+  const fallbackSessionDirectory = normalizeProjectPath(
+    input.meta?.nativeProjectDir ?? input.session?._projectDir ?? input.session?.directory ?? "",
+  );
   const targetDirectory = input.meta?.assignedProjectDir
     ? normalizeProjectPath(input.meta.assignedProjectDir)
-    : null;
+    : input.meta?.pendingDirectoryChangeNotice
+      ? fallbackSessionDirectory
+      : null;
   if (!input.meta?.pendingDirectoryChangeNotice || !targetDirectory) return { text: input.text };
 
   const sourceDirectory = normalizeProjectPath(
-    input.meta.assignedProjectSourceDir ??
-      input.session?._projectDir ??
-      input.session?.directory ??
-      "",
+    input.meta.assignedProjectSourceDir ?? fallbackSessionDirectory,
   );
   const notice = [
     "<SYSTEM-APPEND>",

--- a/src/hooks/agent-local-intent.test.ts
+++ b/src/hooks/agent-local-intent.test.ts
@@ -183,6 +183,55 @@ describe("createLocalIntentOrchestrator", () => {
     );
   });
 
+  test("prepends a directory-change notice when a session is moved back to its original project", async () => {
+    const session = makeSession({
+      id: "session-1",
+      directory: "/project-b",
+      _projectDir: "/project-b",
+      _workspaceId: "workspace-1",
+    });
+    const state = makeState({
+      activeSessionId: session.id,
+      selectedModel: { providerID: "openai", modelID: "gpt-5" },
+      sessions: [session],
+      sessionMeta: {
+        [session.id]: {
+          nativeProjectDir: "/original",
+          assignedProjectDir: null,
+          assignedProjectSourceDir: "/project-b",
+          pendingDirectoryChangeNotice: true,
+        },
+      },
+    });
+    const prompts: Array<Record<string, unknown>> = [];
+
+    const orchestrator = createLocalIntentOrchestrator({
+      getState: () => state,
+      getResourceRuntime: () => undefined,
+      getCurrentVariant: () => undefined,
+      sessionsClient: {
+        prompt: async (input: Record<string, unknown>) => {
+          prompts.push(input);
+        },
+        abort: async () => undefined,
+      } as never,
+      createSession: async () => null,
+      scheduleSessionMessageReconcile: () => undefined,
+      requestSessionAutoName: () => undefined,
+      dispatch: () => undefined,
+      sessionCreatingRef: { current: false },
+    });
+
+    await orchestrator.sendPrompt("Where are you?");
+
+    expect(prompts).toHaveLength(1);
+    expect(String(prompts[0]?.text)).toContain("`/project-b`");
+    expect(String(prompts[0]?.text)).toContain("`/original`");
+    expect(prompts[0]).toMatchObject({
+      target: { directory: "/original", workspaceId: "workspace-1" },
+    });
+  });
+
   test("queues busy-session prompts without creating an optimistic turn", async () => {
     const session = makeSession({
       id: "opencode:session-1",

--- a/src/hooks/agent-local-intent.ts
+++ b/src/hooks/agent-local-intent.ts
@@ -198,6 +198,7 @@ export function createLocalIntentOrchestrator(
       const { projectTarget } = await sendPromptToAgent({
         sessions: sessionsClient,
         session: currentSession,
+        sessionMeta: currentSession ? currentState.sessionMeta[currentSession.id] : undefined,
         sessionId,
         text,
         selection,
@@ -299,7 +300,8 @@ export function createLocalIntentOrchestrator(
         await sessionsClient.abort({
           sessionId: intent.sessionId,
           harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
-          target: getSessionProjectTarget(session) ?? undefined,
+          target:
+            getSessionProjectTarget(session, current.sessionMeta[intent.sessionId]) ?? undefined,
         });
       }
       return;
@@ -334,6 +336,7 @@ export function createLocalIntentOrchestrator(
       const { projectTarget } = await sendCommandToAgent({
         runtime: commandRuntime,
         session: latestSession,
+        sessionMeta: latestSession ? getState().sessionMeta[latestSession.id] : undefined,
         sessionId,
         command,
         args,
@@ -413,6 +416,7 @@ export function useLocalIntentOrchestration(
       currentBusySessionIds: state.busySessionIds,
       activeSessionId: getState().activeSessionId,
       sessions: getState().sessions,
+      sessionMeta: getState().sessionMeta,
       refreshSessionMessages,
     });
     setJustIdledMap((prev) => {
@@ -433,7 +437,11 @@ export function useLocalIntentOrchestration(
         return sessionsClient.abort({
           ...input,
           harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
-          target: getSessionProjectTarget(session) ?? undefined,
+          target:
+            getSessionProjectTarget(
+              session,
+              session ? getState().sessionMeta[session.id] : undefined,
+            ) ?? undefined,
         });
       },
       dispatch: dispatch as never,

--- a/src/hooks/agent-queue-dispatch.test.ts
+++ b/src/hooks/agent-queue-dispatch.test.ts
@@ -22,6 +22,7 @@ describe("processBusyToIdleTransitions", () => {
       previousBusySessionIds: new Set(["session-1", "session-2"]),
       currentBusySessionIds: new Set(["session-2"]),
       activeSessionId: "session-1",
+      sessionMeta: {},
       sessions: [
         makeSession({
           id: "session-1",
@@ -39,6 +40,34 @@ describe("processBusyToIdleTransitions", () => {
       {
         sessionId: "session-1",
         projectTarget: { directory: "/repo", workspaceId: "workspace-1" },
+      },
+    ]);
+  });
+
+  test("refreshes newly idle moved sessions at the assigned project target", () => {
+    const refreshed: Array<Record<string, unknown>> = [];
+
+    processBusyToIdleTransitions({
+      previousBusySessionIds: new Set(["session-1"]),
+      currentBusySessionIds: new Set(),
+      activeSessionId: "session-1",
+      sessionMeta: { "session-1": { assignedProjectDir: "/project-b" } },
+      sessions: [
+        makeSession({
+          id: "session-1",
+          _projectDir: "/project-a",
+          _workspaceId: "workspace-1",
+        }),
+      ],
+      refreshSessionMessages: async (sessionId, projectTarget) => {
+        refreshed.push({ sessionId, projectTarget });
+      },
+    });
+
+    expect(refreshed).toEqual([
+      {
+        sessionId: "session-1",
+        projectTarget: { directory: "/project-b", workspaceId: "workspace-1" },
       },
     ]);
   });

--- a/src/hooks/agent-queue-dispatch.ts
+++ b/src/hooks/agent-queue-dispatch.ts
@@ -1,4 +1,5 @@
 import { getSessionProjectTarget } from "@/hooks/agent-session-utils";
+import type { SessionMetaMap } from "@/hooks/agent-state-persistence";
 import type { Session } from "@/hooks/agent-state-types";
 
 type QueueDispatchAction = {
@@ -11,12 +12,14 @@ export function processBusyToIdleTransitions({
   currentBusySessionIds,
   activeSessionId,
   sessions,
+  sessionMeta,
   refreshSessionMessages,
 }: {
   previousBusySessionIds: Iterable<string>;
   currentBusySessionIds: Set<string>;
   activeSessionId: string | null;
   sessions: Session[];
+  sessionMeta: SessionMetaMap;
   refreshSessionMessages: (
     sessionId: string,
     projectTarget?: { directory?: string; workspaceId?: string },
@@ -30,6 +33,7 @@ export function processBusyToIdleTransitions({
     if (sessionId === activeSessionId) {
       const projectTarget = getSessionProjectTarget(
         sessions.find((session) => session.id === sessionId),
+        sessionMeta[sessionId],
       );
       void refreshSessionMessages(sessionId, projectTarget ?? undefined).catch(() => {
         /* best-effort final transcript reconcile */

--- a/src/hooks/agent-reducer.test.ts
+++ b/src/hooks/agent-reducer.test.ts
@@ -195,4 +195,26 @@ describe("mergeProjectBackendSessions", () => {
 
     expect(next.sessions.map((item) => item.id)).toEqual(["chat-1"]);
   });
+
+  test("keeps chat-origin sessions in the default chat directory when project indexes echo them", () => {
+    const state = baseState({
+      defaultChatDirectory: "/home/tobias/Dokumente",
+      sessions: [session("opencode:chat-1", "opencode", "/home/tobias/Dokumente", 1)],
+      sessionMeta: {
+        "opencode:chat-1": {
+          originMode: "chat",
+          nativeProjectDir: "/home/tobias/Dokumente",
+          assignedProjectDir: null,
+        },
+      },
+    });
+
+    const next = reducer(state, {
+      type: "SESSION_UPDATED",
+      payload: session("opencode:chat-1", "opencode", "/home/tobias/Dokumente/Jutta Kürzl", 2),
+    } as Parameters<typeof reducer>[1]);
+
+    expect(next.sessions[0]?._projectDir).toBe("/home/tobias/Dokumente");
+    expect(next.sessions[0]?.directory).toBe("/home/tobias/Dokumente");
+  });
 });

--- a/src/hooks/agent-reducer.ts
+++ b/src/hooks/agent-reducer.ts
@@ -384,6 +384,29 @@ function getAssignedProjectDir(sessionMeta: InternalAgentState["sessionMeta"], s
   return assigned ? normalizeProjectPath(assigned) : null;
 }
 
+function preserveChatSessionDirectory(state: InternalAgentState, incoming: Session): Session {
+  const meta = state.sessionMeta[incoming.id];
+  if (meta?.originMode !== "chat") return incoming;
+  if (normalizeProjectPath(meta.assignedProjectDir ?? "")) return incoming;
+
+  const existing = state.sessions.find((session) => sameBackendSession(session, incoming));
+  const directory = normalizeProjectPath(
+    (meta.nativeProjectDir ??
+      existing?._projectDir ??
+      existing?.directory ??
+      state.defaultChatDirectory ??
+      "") ||
+      "",
+  );
+  if (!directory) return incoming;
+
+  return {
+    ...incoming,
+    directory,
+    _projectDir: directory,
+  };
+}
+
 export function reducer(state: InternalAgentState, action: Action): InternalAgentState {
   switch (action.type) {
     case "SET_WORKSPACES":
@@ -1039,33 +1062,34 @@ export function reducer(state: InternalAgentState, action: Action): InternalAgen
     }
 
     case "SESSION_CREATED": {
+      const created = preserveChatSessionDirectory(state, action.payload);
       // Ignore subagent / child sessions - only root sessions appear in the sidebar.
-      if (action.payload.parentID) return state;
+      if (created.parentID) return state;
       // Ignore backend echoes for sessions that were optimistically deleted.
-      if (state._deletedSessionIds.has(action.payload.id)) return state;
-      const assignedProjectDir = getAssignedProjectDir(state.sessionMeta, action.payload.id);
+      if (state._deletedSessionIds.has(created.id)) return state;
+      const assignedProjectDir = getAssignedProjectDir(state.sessionMeta, created.id);
       const sessionDirectory = normalizeProjectPath(
-        (action.payload._projectDir ?? action.payload.directory) || "",
+        (created._projectDir ?? created.directory) || "",
       );
       if (assignedProjectDir && sessionDirectory !== assignedProjectDir) return state;
       const previousActiveSession = state.activeSessionId
         ? state.sessions.find((session) => session.id === state.activeSessionId)
         : null;
       const shouldCanonicalizeActive = previousActiveSession
-        ? sameBackendSession(previousActiveSession, action.payload)
+        ? sameBackendSession(previousActiveSession, created)
         : false;
       return {
         ...state,
-        activeSessionId: shouldCanonicalizeActive ? action.payload.id : state.activeSessionId,
+        activeSessionId: shouldCanonicalizeActive ? created.id : state.activeSessionId,
         sessions: sortSessionsNewestFirst([
-          action.payload,
-          ...state.sessions.filter((s) => !sameBackendSession(s, action.payload)),
+          created,
+          ...state.sessions.filter((s) => !sameBackendSession(s, created)),
         ]),
       };
     }
 
     case "SESSION_UPDATED": {
-      const updated = action.payload;
+      const updated = preserveChatSessionDirectory(state, action.payload);
       // Ignore subagent / child sessions - only root sessions appear in the sidebar.
       if (updated.parentID) return state;
       // Ignore backend echoes for sessions that were optimistically deleted.
@@ -1873,7 +1897,17 @@ export function reducer(state: InternalAgentState, action: Action): InternalAgen
       const existing = nextMeta[sessionId] ?? {};
       nextMeta[sessionId] = { ...existing, ...meta };
       persistSessionMetaMap(nextMeta);
-      return { ...state, sessionMeta: nextMeta };
+      const affectsSidebarPlacement =
+        Object.hasOwn(meta, "originMode") ||
+        Object.hasOwn(meta, "assignedProjectDir") ||
+        Object.hasOwn(meta, "detachedFromProject");
+      return {
+        ...state,
+        sessionMeta: nextMeta,
+        sessions: affectsSidebarPlacement
+          ? state.sessions.map((session) => (session.id === sessionId ? { ...session } : session))
+          : state.sessions,
+      };
     }
 
     case "SET_PROJECT_META": {

--- a/src/hooks/agent-send.test.ts
+++ b/src/hooks/agent-send.test.ts
@@ -54,6 +54,34 @@ describe("sendPromptToAgent", () => {
       projectTarget: { directory: "/repo", workspaceId: "workspace-1" },
     });
   });
+
+  test("uses assigned project directory when a session was moved in the sidebar", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const prompt = async (input: Record<string, unknown>) => {
+      calls.push(input);
+    };
+
+    await sendPromptToAgent({
+      sessions: { prompt } as never,
+      session: {
+        id: "opencode:session-1",
+        directory: "/home/tobias/Dokumente",
+        _projectDir: "/home/tobias/Dokumente",
+        _workspaceId: "workspace-1",
+        _harnessId: "opencode",
+      } as never,
+      sessionMeta: {
+        assignedProjectDir: "/home/tobias/Dokumente/Jutta Kürzl",
+      },
+      sessionId: "opencode:session-1",
+      text: "where are you?",
+      selection: { agent: "build" },
+    });
+
+    expect(calls[0]).toMatchObject({
+      target: { directory: "/home/tobias/Dokumente/Jutta Kürzl", workspaceId: "workspace-1" },
+    });
+  });
 });
 
 describe("sendCommandToAgent", () => {
@@ -88,6 +116,35 @@ describe("sendCommandToAgent", () => {
     });
     expect(result).toEqual({
       projectTarget: { directory: "/repo", workspaceId: "workspace-1" },
+    });
+  });
+
+  test("uses assigned project directory for commands after sidebar moves", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const sendCommand = async (input: Record<string, unknown>) => {
+      calls.push(input);
+    };
+
+    await sendCommandToAgent({
+      runtime: { sendCommand } as never,
+      session: {
+        id: "opencode:session-1",
+        directory: "/home/tobias/Dokumente",
+        _projectDir: "/home/tobias/Dokumente",
+        _workspaceId: "workspace-1",
+      } as never,
+      sessionMeta: {
+        assignedProjectDir: "/home/tobias/Dokumente/Jutta Kürzl",
+      },
+      sessionId: "opencode:session-1",
+      command: "review",
+      args: "",
+      selection: {},
+    });
+
+    expect(calls[0]).toMatchObject({
+      directory: "/home/tobias/Dokumente/Jutta Kürzl",
+      workspaceId: "workspace-1",
     });
   });
 });

--- a/src/hooks/agent-send.ts
+++ b/src/hooks/agent-send.ts
@@ -2,6 +2,7 @@ import type { Agent } from "@opencode-ai/sdk/v2/client";
 import type { HarnessDescriptor, HarnessTarget } from "@/agents/backend";
 import { resolveSessionHarnessRoute } from "@/hooks/agent-harness-routing";
 import { getSessionProjectTarget } from "@/hooks/agent-session-utils";
+import type { SessionMeta } from "@/hooks/agent-state-persistence";
 import type { Session } from "@/hooks/agent-state-types";
 import type { VariantSelections } from "@/hooks/use-agent-variant-core";
 import { resolveVariant } from "@/hooks/use-agent-variant-core";
@@ -42,6 +43,7 @@ export function resolveAgentSendSelection(
 export async function sendPromptToAgent({
   sessions,
   session,
+  sessionMeta,
   sessionId,
   text,
   selection,
@@ -51,6 +53,7 @@ export async function sendPromptToAgent({
 }: {
   sessions: OpenGuiClient["sessions"];
   session: Session | null | undefined;
+  sessionMeta?: SessionMeta;
   sessionId: string;
   text: string;
   selection: AgentSendSelection;
@@ -58,7 +61,7 @@ export async function sendPromptToAgent({
   getWorkspaceBaseUrl?: (workspaceId?: string | null) => string | undefined;
   mode?: QueueMode;
 }): Promise<{ projectTarget?: HarnessTarget }> {
-  const rawProjectTarget = getSessionProjectTarget(session) ?? undefined;
+  const rawProjectTarget = getSessionProjectTarget(session, sessionMeta) ?? undefined;
   const workspaceId = rawProjectTarget?.workspaceId ?? activeWorkspaceId;
   const baseUrl = getWorkspaceBaseUrl?.(workspaceId);
   const projectTarget =
@@ -82,6 +85,7 @@ export async function sendPromptToAgent({
 export async function sendCommandToAgent({
   runtime,
   session,
+  sessionMeta,
   sessionId,
   command,
   args,
@@ -89,12 +93,13 @@ export async function sendCommandToAgent({
 }: {
   runtime: HarnessDescriptor["runtime"];
   session: Session | null | undefined;
+  sessionMeta?: SessionMeta;
   sessionId: string;
   command: string;
   args: string;
   selection: AgentSendSelection;
 }): Promise<{ projectTarget?: HarnessTarget }> {
-  const projectTarget = getSessionProjectTarget(session) ?? undefined;
+  const projectTarget = getSessionProjectTarget(session, sessionMeta) ?? undefined;
 
   await runtime.sendCommand({
     sessionId,

--- a/src/hooks/agent-session-activation.ts
+++ b/src/hooks/agent-session-activation.ts
@@ -171,7 +171,10 @@ export function useAgentSessionActivation({
         options?.session && options.session.id === id
           ? options.session
           : stateRef.current.sessions.find((session) => session.id === id);
-      const projectTarget = getSessionProjectTarget(resolvedSession);
+      const projectTarget = getSessionProjectTarget(
+        resolvedSession,
+        resolvedSession ? stateRef.current.sessionMeta[resolvedSession.id] : undefined,
+      );
 
       if (hadCompleteBuffer && bufferMessages) {
         applySelectionFromMessages(bufferMessages);

--- a/src/hooks/agent-session-lifecycle.test.ts
+++ b/src/hooks/agent-session-lifecycle.test.ts
@@ -150,7 +150,7 @@ describe("createLifecycleSession", () => {
       type: "SET_SESSION_META",
       payload: {
         sessionId: "session-1",
-        meta: { originMode: "chat", assignedProjectDir: null },
+        meta: { originMode: "chat", nativeProjectDir: "/chat", assignedProjectDir: null },
       },
     });
     expect(selected).toEqual([{ sessionId: "session-1", session: created }]);

--- a/src/hooks/agent-session-lifecycle.ts
+++ b/src/hooks/agent-session-lifecycle.ts
@@ -1,5 +1,5 @@
 import type { HarnessId } from "@/agents";
-import type { WorktreeParentMap } from "@/hooks/agent-state-persistence";
+import type { SessionMeta, WorktreeParentMap } from "@/hooks/agent-state-persistence";
 import { resolvePendingPromptCreationHarnessRoute } from "@/hooks/agent-harness-routing";
 import { getSessionHarnessId, getSessionProjectTarget } from "@/hooks/agent-session-utils";
 import type { MessageEntry, Session } from "@/hooks/agent-state-types";
@@ -20,10 +20,7 @@ type LifecycleAction =
       type: "SET_SESSION_META";
       payload: {
         sessionId: string;
-        meta: {
-          originMode: "chat";
-          assignedProjectDir: null;
-        };
+        meta: Partial<SessionMeta>;
       };
     }
   | {
@@ -254,7 +251,7 @@ export async function createLifecycleSession({
         type: "SET_SESSION_META",
         payload: {
           sessionId: session.id,
-          meta: { originMode: "chat", assignedProjectDir: null },
+          meta: { originMode: "chat", nativeProjectDir: directory, assignedProjectDir: null },
         },
       });
     }

--- a/src/hooks/agent-session-queue.ts
+++ b/src/hooks/agent-session-queue.ts
@@ -1,10 +1,11 @@
 import { resolveSessionHarnessRoute } from "@/hooks/agent-harness-routing";
 import { getSessionProjectTarget } from "@/hooks/agent-session-utils";
+import type { SessionMetaMap } from "@/hooks/agent-state-persistence";
 import type { InternalAgentState, QueuedPrompt, Session } from "@/hooks/agent-state-types";
 import type { OpenGuiClient, QueueScopeInput } from "@/protocol/client";
 
 interface SessionQueueOptions {
-  getState: () => Pick<InternalAgentState, "sessions">;
+  getState: () => Pick<InternalAgentState, "sessions" | "sessionMeta">;
   sessionsClient: OpenGuiClient["sessions"];
   dispatch: (action: unknown) => void;
 }
@@ -25,9 +26,13 @@ export interface SessionQueueOrchestrator {
   sendNow(this: void, sessionId: string, promptId: string): Promise<void>;
 }
 
-function getSessionLookup(session: Session | undefined): QueueScopeInput {
+function getSessionLookup(
+  session: Session | undefined,
+  sessionMeta: SessionMetaMap,
+): QueueScopeInput {
   const harnessId = resolveSessionHarnessRoute(session).harnessId ?? undefined;
-  const target = getSessionProjectTarget(session) ?? undefined;
+  const target =
+    getSessionProjectTarget(session, session ? sessionMeta[session.id] : undefined) ?? undefined;
   if (!harnessId || !target?.directory) {
     throw new Error("Queued prompt target requires Harness, Project directory, and Session ID");
   }
@@ -39,8 +44,13 @@ export function createSessionQueueOrchestrator(
 ): SessionQueueOrchestrator {
   const { getState, sessionsClient, dispatch } = options;
 
-  const lookup = (sessionId: string) =>
-    getSessionLookup(getState().sessions.find((session) => session.id === sessionId));
+  const lookup = (sessionId: string) => {
+    const state = getState();
+    return getSessionLookup(
+      state.sessions.find((session) => session.id === sessionId),
+      state.sessionMeta,
+    );
+  };
 
   const setSnapshot = (sessionId: string, prompts: QueuedPrompt[]) => {
     dispatch({ type: "SET_SESSION_QUEUE", payload: { sessionID: sessionId, prompts } });

--- a/src/hooks/agent-session-utils.test.ts
+++ b/src/hooks/agent-session-utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import type { Session } from "@/hooks/agent-state-types";
+import {
+  createSessionProjectDetachMeta,
+  createSessionProjectMoveMeta,
+} from "./agent-session-utils";
+
+function session(directory: string): Session {
+  return {
+    id: "session-1",
+    title: "Session",
+    directory,
+    _projectDir: directory,
+    time: { created: 1, updated: 1 },
+  } as Session;
+}
+
+describe("createSessionProjectMoveMeta", () => {
+  test("marks a normal project move as requiring a directory-change notice", () => {
+    expect(
+      createSessionProjectMoveMeta(session("/project-a"), undefined, "/project-b", 10),
+    ).toEqual({
+      originMode: "project",
+      nativeProjectDir: "/project-a",
+      assignedProjectDir: "/project-b",
+      assignedProjectMovedAt: 10,
+      assignedProjectSourceDir: "/project-a",
+      pendingDirectoryChangeNotice: true,
+      hideSystemAppendBlocks: true,
+      detachedFromProject: false,
+      detachedFromProjectAt: null,
+    });
+  });
+
+  test("still marks a move back to the native project as requiring a notice", () => {
+    expect(
+      createSessionProjectMoveMeta(
+        session("/project-b"),
+        { nativeProjectDir: "/project-a", assignedProjectDir: "/project-b" },
+        "/project-a",
+        20,
+      ),
+    ).toEqual({
+      originMode: "project",
+      nativeProjectDir: "/project-a",
+      assignedProjectDir: null,
+      assignedProjectMovedAt: 20,
+      assignedProjectSourceDir: "/project-b",
+      pendingDirectoryChangeNotice: true,
+      hideSystemAppendBlocks: true,
+      detachedFromProject: false,
+      detachedFromProjectAt: null,
+    });
+  });
+});
+
+describe("createSessionProjectDetachMeta", () => {
+  test("marks removing a moved session back to Chats as requiring a notice", () => {
+    expect(
+      createSessionProjectDetachMeta(
+        session("/chat-root"),
+        { assignedProjectDir: "/project-b" },
+        30,
+      ),
+    ).toEqual({
+      originMode: "chat",
+      nativeProjectDir: "/chat-root",
+      assignedProjectDir: null,
+      assignedProjectMovedAt: null,
+      assignedProjectSourceDir: "/project-b",
+      pendingDirectoryChangeNotice: true,
+      hideSystemAppendBlocks: true,
+      detachedFromProject: true,
+      detachedFromProjectAt: 30,
+    });
+  });
+
+  test("uses the stored native directory when backend echoes changed the session project", () => {
+    expect(
+      createSessionProjectDetachMeta(
+        session("/project-b"),
+        { nativeProjectDir: "/chat-root", assignedProjectDir: "/project-b" },
+        40,
+      ),
+    ).toEqual({
+      originMode: "chat",
+      nativeProjectDir: "/chat-root",
+      assignedProjectDir: null,
+      assignedProjectMovedAt: null,
+      assignedProjectSourceDir: "/project-b",
+      pendingDirectoryChangeNotice: true,
+      hideSystemAppendBlocks: true,
+      detachedFromProject: true,
+      detachedFromProjectAt: 40,
+    });
+  });
+});

--- a/src/hooks/agent-session-utils.ts
+++ b/src/hooks/agent-session-utils.ts
@@ -1,6 +1,6 @@
 import { normalizeProjectPath } from "@/lib/utils";
 import { getHarnessIdFromSessionId, type HarnessId } from "@/agents";
-import type { ProjectMetaMap } from "@/hooks/agent-state-persistence";
+import type { ProjectMetaMap, SessionMeta } from "@/hooks/agent-state-persistence";
 import type { Session } from "@/hooks/agent-state-types";
 import type { SelectedModel } from "@/types/electron";
 
@@ -26,6 +26,74 @@ export function getSessionDirectory(session: Session | undefined | null) {
   return session._projectDir ?? session.directory ?? null;
 }
 
+export function getEffectiveSessionDirectory(
+  session: Session | undefined | null,
+  meta?: SessionMeta,
+) {
+  const assignedDirectory = meta?.assignedProjectDir
+    ? normalizeProjectPath(meta.assignedProjectDir)
+    : "";
+  const nativeDirectory = meta?.nativeProjectDir ? normalizeProjectPath(meta.nativeProjectDir) : "";
+  const sessionDirectory = normalizeProjectPath(getSessionDirectory(session) ?? "");
+  return assignedDirectory || nativeDirectory || sessionDirectory || null;
+}
+
+export function createSessionProjectMoveMeta(
+  session: Session | undefined | null,
+  meta: SessionMeta | undefined,
+  targetDirectory: string,
+  now = Date.now(),
+): Partial<SessionMeta> | null {
+  const nativeDirectory = normalizeProjectPath(
+    meta?.nativeProjectDir ?? getSessionDirectory(session) ?? "",
+  );
+  const normalizedTargetDirectory = normalizeProjectPath(targetDirectory);
+  if (!nativeDirectory || !normalizedTargetDirectory) return null;
+
+  const currentDirectory = getEffectiveSessionDirectory(session, meta) ?? nativeDirectory;
+  const directoryChanged = currentDirectory !== normalizedTargetDirectory;
+
+  return {
+    originMode: meta?.originMode === "chat" ? "chat" : "project",
+    nativeProjectDir: nativeDirectory,
+    assignedProjectDir:
+      nativeDirectory === normalizedTargetDirectory ? null : normalizedTargetDirectory,
+    assignedProjectMovedAt: directoryChanged ? now : null,
+    assignedProjectSourceDir: directoryChanged ? currentDirectory : null,
+    pendingDirectoryChangeNotice: directoryChanged,
+    hideSystemAppendBlocks: directoryChanged,
+    detachedFromProject: false,
+    detachedFromProjectAt: null,
+  };
+}
+
+export function createSessionProjectDetachMeta(
+  session: Session | undefined | null,
+  meta: SessionMeta | undefined,
+  now = Date.now(),
+  fallbackDirectory?: string | null,
+): Partial<SessionMeta> | null {
+  const nativeDirectory = normalizeProjectPath(
+    meta?.nativeProjectDir ?? fallbackDirectory ?? getSessionDirectory(session) ?? "",
+  );
+  if (!nativeDirectory) return null;
+
+  const currentDirectory = getEffectiveSessionDirectory(session, meta) ?? nativeDirectory;
+  const directoryChanged = currentDirectory !== nativeDirectory;
+
+  return {
+    originMode: "chat",
+    nativeProjectDir: nativeDirectory,
+    assignedProjectDir: null,
+    assignedProjectMovedAt: null,
+    assignedProjectSourceDir: directoryChanged ? currentDirectory : null,
+    pendingDirectoryChangeNotice: directoryChanged,
+    hideSystemAppendBlocks: directoryChanged,
+    detachedFromProject: true,
+    detachedFromProjectAt: now,
+  };
+}
+
 export function getSessionWorkspaceId(session: Session | undefined | null) {
   if (!session) return null;
   return session._workspaceId ?? null;
@@ -37,8 +105,11 @@ export type ProjectTarget = {
   baseUrl?: string;
 };
 
-export function getSessionProjectTarget(session: Session | undefined | null): ProjectTarget | null {
-  const directory = getSessionDirectory(session);
+export function getSessionProjectTarget(
+  session: Session | undefined | null,
+  meta?: SessionMeta,
+): ProjectTarget | null {
+  const directory = getEffectiveSessionDirectory(session, meta);
   if (!directory) return null;
   return {
     directory,

--- a/src/hooks/agent-state-persistence.ts
+++ b/src/hooks/agent-state-persistence.ts
@@ -51,6 +51,7 @@ export interface SessionMeta {
   selectedAgent?: string | null;
   selectedVariant?: string | null;
   originMode?: "chat" | "project";
+  nativeProjectDir?: string | null;
   assignedProjectDir?: string | null;
   assignedProjectMovedAt?: number | null;
   assignedProjectSourceDir?: string | null;
@@ -96,6 +97,7 @@ export function persistSessionMetaMap(meta: SessionMetaMap) {
       Object.hasOwn(m, "selectedAgent") ||
       Object.hasOwn(m, "selectedVariant") ||
       m.originMode === "chat" ||
+      Object.hasOwn(m, "nativeProjectDir") ||
       Object.hasOwn(m, "assignedProjectDir") ||
       Object.hasOwn(m, "assignedProjectMovedAt") ||
       Object.hasOwn(m, "assignedProjectSourceDir") ||

--- a/src/hooks/use-agent-impl-core.tsx
+++ b/src/hooks/use-agent-impl-core.tsx
@@ -92,6 +92,8 @@ import {
   loadOlderSessionMessages,
 } from "@/hooks/agent-message-loading";
 import {
+  createSessionProjectDetachMeta,
+  createSessionProjectMoveMeta,
   getSessionProjectTarget,
   getSessionSelectedAgent,
   getSessionWorkspaceId,
@@ -1356,7 +1358,8 @@ function InternalAgentProvider({
   useEffect(() => {
     if (!resourceBridge || !activeResourceDirectory) return;
     const activeProjectKey = makeProjectKey(activeWorkspace?.id, activeResourceDirectory);
-    if (!(activeProjectKey in state.connections)) return;
+    const activeConnection = state.connections[activeProjectKey];
+    if (activeConnection?.state !== "connected") return;
     const activeWorkspaceId = activeWorkspace?.id;
     const cached = activeWorkspaceId ? state.workspaceResources[activeWorkspaceId] : undefined;
     if (
@@ -1522,7 +1525,10 @@ function InternalAgentProvider({
           title: trimmed,
           harnessId: resolveSessionHarnessRoute(current).harnessId ?? undefined,
           target: (() => {
-            const target = getSessionProjectTarget(current);
+            const target = getSessionProjectTarget(
+              current,
+              current ? stateRef.current.sessionMeta[current.id] : undefined,
+            );
             const workspaceId = target?.workspaceId ?? stateRef.current.activeWorkspaceId;
             const workspace = workspaceId
               ? stateRef.current.workspaces.find((item) => item.id === workspaceId)
@@ -1575,8 +1581,17 @@ function InternalAgentProvider({
       projectTarget?: { directory?: string; workspaceId?: string },
     ) => {
       const session = stateRef.current.sessions.find((candidate) => candidate.id === sessionId);
+      const resolvedProjectTarget =
+        projectTarget ??
+        getSessionProjectTarget(
+          session,
+          session ? stateRef.current.sessionMeta[session.id] : undefined,
+        ) ??
+        undefined;
       const workspaceId =
-        projectTarget?.workspaceId ?? session?._workspaceId ?? stateRef.current.activeWorkspaceId;
+        resolvedProjectTarget?.workspaceId ??
+        session?._workspaceId ??
+        stateRef.current.activeWorkspaceId;
       const workspace = stateRef.current.workspaces.find(
         (candidate) => candidate.id === workspaceId,
       );
@@ -1587,8 +1602,8 @@ function InternalAgentProvider({
         options,
         projectTarget:
           workspace && !workspace.isLocal
-            ? { ...projectTarget, baseUrl: workspace.serverUrl, workspaceId }
-            : projectTarget,
+            ? { ...resolvedProjectTarget, baseUrl: workspace.serverUrl, workspaceId }
+            : resolvedProjectTarget,
       });
     },
     [openGuiClient],
@@ -1799,7 +1814,13 @@ function InternalAgentProvider({
           sessionId: id,
           title: plan.trimmedTitle,
           harnessId: resolveSessionHarnessRoute(plan.currentSession).harnessId ?? undefined,
-          target: getSessionProjectTarget(plan.currentSession) ?? undefined,
+          target:
+            getSessionProjectTarget(
+              plan.currentSession,
+              plan.currentSession
+                ? stateRef.current.sessionMeta[plan.currentSession.id]
+                : undefined,
+            ) ?? undefined,
         })
         .catch(() => {
           /* best-effort rename – backend events will reconcile */
@@ -1890,6 +1911,7 @@ function InternalAgentProvider({
     try {
       const projectTarget = getSessionProjectTarget(
         stateRef.current.sessions.find((session) => session.id === sessionId),
+        stateRef.current.sessionMeta[sessionId],
       );
       await runtime.compactSession(sessionId, model, projectTarget ?? undefined);
 
@@ -1961,7 +1983,11 @@ function InternalAgentProvider({
     const activeSession = state.sessions.find(
       (session) => session.id === sessionId || session.id === state.activeSessionId,
     );
-    const target = getSessionProjectTarget(activeSession) ?? undefined;
+    const target =
+      getSessionProjectTarget(
+        activeSession,
+        activeSession ? state.sessionMeta[activeSession.id] : undefined,
+      ) ?? undefined;
     const workspaceId = target?.workspaceId ?? state.activeWorkspaceId;
     const workspace = state.workspaces.find((item) => item.id === workspaceId);
     await openGuiClient.sessions.abort({
@@ -1996,7 +2022,9 @@ function InternalAgentProvider({
         permissionId: pending.id,
         response,
         harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
-        target: getSessionProjectTarget(session) ?? undefined,
+        target:
+          getSessionProjectTarget(session, session ? state.sessionMeta[session.id] : undefined) ??
+          undefined,
       });
       dispatch({
         type: "SET_PERMISSION",
@@ -2086,11 +2114,11 @@ function InternalAgentProvider({
   );
 
   const startNewChat = useCallback(async () => {
-    const defaultChatDirectory = stateRef.current.defaultChatDirectory;
+    const defaultChatDirectory = normalizeProjectPath(stateRef.current.defaultChatDirectory ?? "");
     if (!defaultChatDirectory) return;
-    setActiveTarget(defaultChatDirectory);
+    setActiveTarget(defaultChatDirectory, preferredBackendId);
     await ensureDirectoryConnection(defaultChatDirectory, { transient: true });
-  }, [ensureDirectoryConnection, setActiveTarget]);
+  }, [ensureDirectoryConnection, preferredBackendId, setActiveTarget]);
 
   const setActiveTargetDirectory = useCallback(
     (directory: string) => {
@@ -2145,7 +2173,11 @@ function InternalAgentProvider({
   const getQueueTarget = useCallback((sessionId: string) => {
     const session = stateRef.current.sessions.find((item) => item.id === sessionId);
     const harnessId = resolveSessionHarnessRoute(session).harnessId ?? undefined;
-    const target = getSessionProjectTarget(session) ?? undefined;
+    const target =
+      getSessionProjectTarget(
+        session,
+        session ? stateRef.current.sessionMeta[session.id] : undefined,
+      ) ?? undefined;
     if (!harnessId || !target?.directory) {
       throw new Error("Queued prompt target requires Harness, Project directory, and Session ID");
     }
@@ -2252,7 +2284,11 @@ function InternalAgentProvider({
         await openGuiClient.sessions.abort({
           sessionId: state.activeSessionId,
           harnessId: resolveSessionHarnessRoute(activeSession).harnessId ?? undefined,
-          target: getSessionProjectTarget(activeSession) ?? undefined,
+          target:
+            getSessionProjectTarget(
+              activeSession,
+              activeSession ? state.sessionMeta[activeSession.id] : undefined,
+            ) ?? undefined,
         });
       }
       await refreshLifecycleSession({
@@ -2338,26 +2374,21 @@ function InternalAgentProvider({
           (sourceSession._projectDir ?? sourceSession.directory) || "",
         );
         if (!sourceDirectory) return;
-
-        await ensureDirectoryConnection(targetDirectory);
+        const meta = createSessionProjectMoveMeta(
+          sourceSession,
+          stateRef.current.sessionMeta[sessionId],
+          targetDirectory,
+        );
+        if (!meta) return;
 
         dispatch({
           type: "SET_SESSION_META",
           payload: {
             sessionId,
-            meta: {
-              originMode: "project",
-              assignedProjectDir: sourceDirectory === targetDirectory ? null : targetDirectory,
-              assignedProjectMovedAt: sourceDirectory === targetDirectory ? null : Date.now(),
-              assignedProjectSourceDir:
-                sourceDirectory === targetDirectory ? null : sourceDirectory,
-              pendingDirectoryChangeNotice: sourceDirectory !== targetDirectory,
-              hideSystemAppendBlocks: sourceDirectory !== targetDirectory,
-              detachedFromProject: false,
-              detachedFromProjectAt: null,
-            },
+            meta,
           },
         });
+        await ensureDirectoryConnection(targetDirectory);
         await selectSession(sessionId);
       } catch (error) {
         dispatch({
@@ -2381,21 +2412,19 @@ function InternalAgentProvider({
           (sourceSession._projectDir ?? sourceSession.directory) || "",
         );
         if (!sourceDirectory) return;
+        const meta = createSessionProjectDetachMeta(
+          sourceSession,
+          stateRef.current.sessionMeta[sessionId],
+          Date.now(),
+          stateRef.current.defaultChatDirectory,
+        );
+        if (!meta) return;
 
         dispatch({
           type: "SET_SESSION_META",
           payload: {
             sessionId,
-            meta: {
-              originMode: "chat",
-              assignedProjectDir: null,
-              assignedProjectMovedAt: null,
-              assignedProjectSourceDir: null,
-              pendingDirectoryChangeNotice: false,
-              hideSystemAppendBlocks: false,
-              detachedFromProject: true,
-              detachedFromProjectAt: Date.now(),
-            },
+            meta,
           },
         });
         await selectSession(sessionId);


### PR DESCRIPTION
## Summary
- preserve a stable native project directory for sessions moved between Chats and Projects
- use assigned/native session metadata consistently for prompts, queues, refreshes, aborts, and sidebar footer state
- add regression coverage for moving sessions A -> B, B -> A, and B -> Chats/native

## Testing
- vp test src/hooks/agent-session-utils.test.ts src/hooks/agent-directory-change-notice.test.ts src/hooks/agent-local-intent.test.ts src/hooks/agent-send.test.ts src/hooks/agent-queue-dispatch.test.ts src/hooks/agent-reducer.test.ts src/hooks/agent-session-lifecycle.test.ts src/components/sidebar/use-sidebar-model.test.ts
- vp check (passes with existing pi-bridge await-thenable warnings)