### PR TITLE
fix: restore contrast slider track visibility

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -21,7 +21,7 @@ function Slider({
 
   return (
     <SliderPrimitive.Root
-      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+      className={cn("w-full", className)}
       data-slot="slider"
       defaultValue={defaultValue}
       value={value}
@@ -33,14 +33,14 @@ function Slider({
       thumbAlignment="edge"
       {...props}
     >
-      <SliderPrimitive.Control className="relative flex touch-none items-center select-none data-disabled:opacity-50 data-horizontal:h-6 data-horizontal:w-full data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+      <SliderPrimitive.Control className="relative flex h-6 w-full touch-none items-center select-none data-disabled:opacity-50">
         <SliderPrimitive.Track
           data-slot="slider-track"
-          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1.5 data-horizontal:w-full data-vertical:h-full data-vertical:w-1.5"
+          className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted select-none"
         >
           <SliderPrimitive.Indicator
             data-slot="slider-range"
-            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+            className="h-full bg-primary select-none"
           />
         </SliderPrimitive.Track>
         {Array.from({ length: _values.length }, (_, index) => (


### PR DESCRIPTION
## Summary
- restore visible slider track dimensions after Base UI orientation attributes stopped matching styles
- keep the filled slider range on the primary/accent color

## Checks
- vp check