### PR TITLE
fix: route opencode question replies correctly

### DIFF
--- a/opencode-bridge.ts
+++ b/opencode-bridge.ts
@@ -1246,14 +1246,16 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
       if (windowState.projectRegistry.getConnection(projectKey) !== conn) return;
       if (event?.type === "opencode:event") {
         const props = event.payload?.properties ?? {};
-        if (event.payload?.type === "question.asked") {
-          windowState.projectRegistry.rememberQuestion(projectKey, props?.id);
+        const questionId = props?.id ?? props?.requestID;
+        if (event.payload?.type === "question.asked" && questionId) {
+          windowState.projectRegistry.rememberQuestion(projectKey, questionId);
         }
         if (
-          event.payload?.type === "question.replied" ||
-          event.payload?.type === "question.rejected"
+          (event.payload?.type === "question.replied" ||
+            event.payload?.type === "question.rejected") &&
+          questionId
         ) {
-          windowState.projectRegistry.deleteQuestion(props?.requestID);
+          windowState.projectRegistry.deleteQuestion(questionId);
         }
       }
       sendEvent(sender, { ...event, directory, workspaceId });
@@ -1461,19 +1463,20 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
 
   /**
    * Register an IPC handler for question operations that prefers
-   * requestID -> directory routing, then falls back to trying all connections.
+   * explicit target routing, then requestID -> directory routing,
+   * then falls back to a single connected connection.
    * @param {string} channel - IPC channel name
    * @param {(conn: OpenCodeConnection, requestID: string, ...args: any[]) => Promise<any>} fn
    */
-  function handleQuestionOp(channel, fn, targetArgOffset = 0) {
+  function handleQuestionOp(channel, fn) {
     ipcMain.handle(channel, async (event, requestID, ...args) => {
       try {
         const windowState = getWindowState(event.sender);
         if (typeof requestID !== "string" || !requestID.trim()) {
           return { success: false, error: "Question requestID is required" };
         }
-        const maybeDirectory = args[targetArgOffset];
-        const maybeWorkspaceId = args[targetArgOffset + 1];
+        const maybeDirectory = args.length >= 2 ? args[args.length - 2] : undefined;
+        const maybeWorkspaceId = args.length >= 1 ? args[args.length - 1] : undefined;
         const directory = typeof maybeDirectory === "string" ? maybeDirectory : undefined;
         const workspaceId = typeof maybeWorkspaceId === "string" ? maybeWorkspaceId : undefined;
 
@@ -1492,8 +1495,6 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
           windowState.projectRegistry.deleteQuestion(requestID);
           return data === undefined ? { success: true } : { success: true, data };
         }
-
-        windowState.projectRegistry.deleteQuestion(requestID);
 
         const connected = getConnectedConnections(windowState, workspaceId);
         const entry = connected[0];
@@ -1917,12 +1918,10 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
     conn.respondPermission(sessionId, permissionId, response),
   );
 
-  // --- Question response (try all connections) ---
+  // --- Question response (target/question routed) ---
 
-  handleQuestionOp(
-    "opencode:question:reply",
-    (conn, requestID, answers) => conn.replyQuestion(requestID, answers),
-    1,
+  handleQuestionOp("opencode:question:reply", (conn, requestID, answers) =>
+    conn.replyQuestion(requestID, answers),
   );
 
   // --- Commands (global) ---
@@ -1961,11 +1960,7 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
       return { success: false, error: err.message };
     }
   });
-  handleQuestionOp(
-    "opencode:question:reject",
-    (conn, requestID) => conn.rejectQuestion(requestID),
-    0,
-  );
+  handleQuestionOp("opencode:question:reject", (conn, requestID) => conn.rejectQuestion(requestID));
 
   // --- MCP operations (directory-aware) ---
 

--- a/opencode-bridge.ts
+++ b/opencode-bridge.ts
@@ -21,6 +21,7 @@ import { pollUntilEffect, runEffect, sleepEffect } from "./lib/effect-runtime.ts
 import { getOpenCodeProviderAuthKinds } from "./opencode-config.ts";
 import { OpencodeProjectRegistry } from "./opencode-project-registry.ts";
 import { resolveHarnessCli } from "./server/harness-inventory.ts";
+import { normalizeProjectPath } from "./src/lib/path.ts";
 
 // ---------------------------------------------------------------------------
 // Local server management
@@ -226,13 +227,14 @@ function tagOpenCodeSession(session, dir, workspaceId) {
     typeof session.directory === "string" && session.directory.trim()
       ? session.directory.trim()
       : null;
+  const projectDir = sessionDirectory ?? session._projectDir ?? dir;
   return {
     ...session,
     id,
     slug: session.slug ? toFrontendSessionId(session.slug) : id,
     _harnessId: "opencode",
     _rawId: rawId,
-    _projectDir: session._projectDir ?? sessionDirectory ?? dir,
+    _projectDir: projectDir ? normalizeProjectPath(projectDir) : undefined,
     _workspaceId: workspaceId ?? session._workspaceId,
   };
 }
@@ -600,12 +602,21 @@ export class OpenCodeConnection {
 
   async replyQuestion(requestID, answers) {
     this._requireClient();
-    await this._client.question.reply({ requestID, answers });
+    const directory = this.getDirectory();
+    await this._client.question.reply({
+      requestID,
+      answers,
+      ...(directory ? { directory } : {}),
+    });
   }
 
   async rejectQuestion(requestID) {
     this._requireClient();
-    await this._client.question.reject({ requestID });
+    const directory = this.getDirectory();
+    await this._client.question.reject({
+      requestID,
+      ...(directory ? { directory } : {}),
+    });
   }
 
   // - MCP ------------------------------------------------------------------
@@ -778,7 +789,6 @@ export class OpenCodeConnection {
           if (!raw) continue;
           const event = JSON.parse(raw);
           const payload = event.payload ?? event;
-          if (payload?.type === "sync") continue;
           if (payload) {
             this._emit({ type: "opencode:event", payload });
             this._status.lastEventAt = Date.now();
@@ -1297,7 +1307,7 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
     if (typeof directory !== "string" || !directory.trim()) {
       return getAnyConnectionEntry(windowState, workspaceId);
     }
-    return windowState.projectRegistry.getExactConnectionEntry({ directory, workspaceId });
+    return windowState.projectRegistry.getDirectoryConnectionEntry({ directory, workspaceId });
   }
 
   function getConnectionForDirectory(windowState, directory, workspaceId) {
@@ -1455,12 +1465,25 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
    * @param {string} channel - IPC channel name
    * @param {(conn: OpenCodeConnection, requestID: string, ...args: any[]) => Promise<any>} fn
    */
-  function handleQuestionOp(channel, fn) {
+  function handleQuestionOp(channel, fn, targetArgOffset = 0) {
     ipcMain.handle(channel, async (event, requestID, ...args) => {
       try {
         const windowState = getWindowState(event.sender);
         if (typeof requestID !== "string" || !requestID.trim()) {
           return { success: false, error: "Question requestID is required" };
+        }
+        const maybeDirectory = args[targetArgOffset];
+        const maybeWorkspaceId = args[targetArgOffset + 1];
+        const directory = typeof maybeDirectory === "string" ? maybeDirectory : undefined;
+        const workspaceId = typeof maybeWorkspaceId === "string" ? maybeWorkspaceId : undefined;
+
+        const targetEntry = directory
+          ? getConnectionEntryForDirectory(windowState, directory, workspaceId)
+          : null;
+        if (targetEntry) {
+          const data = await fn(targetEntry.connection, requestID, ...args);
+          windowState.projectRegistry.deleteQuestion(requestID);
+          return data === undefined ? { success: true } : { success: true, data };
         }
 
         const mappedEntry = windowState.projectRegistry.getMappedQuestionConnectionEntry(requestID);
@@ -1469,10 +1492,12 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
           windowState.projectRegistry.deleteQuestion(requestID);
           return data === undefined ? { success: true } : { success: true, data };
         }
+
         windowState.projectRegistry.deleteQuestion(requestID);
 
-        const entry = getAnyConnectionEntry(windowState);
-        if (entry && getConnectedConnections(windowState).length === 1) {
+        const connected = getConnectedConnections(windowState, workspaceId);
+        const entry = connected[0];
+        if (entry && connected.length === 1) {
           const data = await fn(entry.connection, requestID, ...args);
           windowState.projectRegistry.deleteQuestion(requestID);
           return data === undefined ? { success: true } : { success: true, data };
@@ -1894,8 +1919,10 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
 
   // --- Question response (try all connections) ---
 
-  handleQuestionOp("opencode:question:reply", (conn, requestID, answers) =>
-    conn.replyQuestion(requestID, answers),
+  handleQuestionOp(
+    "opencode:question:reply",
+    (conn, requestID, answers) => conn.replyQuestion(requestID, answers),
+    1,
   );
 
   // --- Commands (global) ---
@@ -1934,7 +1961,11 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
       return { success: false, error: err.message };
     }
   });
-  handleQuestionOp("opencode:question:reject", (conn, requestID) => conn.rejectQuestion(requestID));
+  handleQuestionOp(
+    "opencode:question:reject",
+    (conn, requestID) => conn.rejectQuestion(requestID),
+    0,
+  );
 
   // --- MCP operations (directory-aware) ---
 

--- a/opencode-project-registry.ts
+++ b/opencode-project-registry.ts
@@ -1,20 +1,26 @@
 // @ts-nocheck
-import { normalize } from "node:path";
+import { normalizeProjectPath } from "./src/lib/path.ts";
+
+const PROJECT_KEY_SEPARATOR = "\u0000";
 
 export class OpencodeProjectRegistry {
   connections = new Map();
   questionProjectKeys = new Map();
 
-  createProjectKey(_workspaceId, directory) {
-    return normalize(String(directory || "").trim());
+  createProjectKey(workspaceId, directory) {
+    return `${String(workspaceId || "")}${PROJECT_KEY_SEPARATOR}${normalizeProjectPath(
+      String(directory || ""),
+    )}`;
   }
 
-  getWorkspaceIdFromProjectKey(_projectKey) {
-    return "";
+  getWorkspaceIdFromProjectKey(projectKey) {
+    const raw = String(projectKey || "");
+    const idx = raw.indexOf(PROJECT_KEY_SEPARATOR);
+    return idx < 0 ? "" : raw.slice(0, idx);
   }
 
   setConnection(target, connection) {
-    const projectKey = this.createProjectKey(null, target.directory);
+    const projectKey = this.createProjectKey(target.workspaceId, target.directory);
     this.connections.set(projectKey, connection);
     return { projectKey, connection };
   }
@@ -31,9 +37,25 @@ export class OpencodeProjectRegistry {
 
   getExactConnectionEntry(target) {
     if (typeof target.directory !== "string" || !target.directory.trim()) return null;
-    const projectKey = this.createProjectKey(null, target.directory);
+    const projectKey = this.createProjectKey(target.workspaceId, target.directory);
     const connection = this.connections.get(projectKey);
     return connection ? { projectKey, connection } : null;
+  }
+
+  getDirectoryConnectionEntry(target) {
+    const directory = normalizeProjectPath(String(target.directory || ""));
+    if (!directory) return null;
+    const exact = this.getExactConnectionEntry(target);
+    if (exact) return exact;
+    const matches = [];
+    for (const [projectKey, connection] of this.connections) {
+      const idx = String(projectKey).indexOf(PROJECT_KEY_SEPARATOR);
+      const keyWorkspaceId = idx < 0 ? "" : String(projectKey).slice(0, idx);
+      const keyDirectory = idx < 0 ? String(projectKey) : String(projectKey).slice(idx + 1);
+      if (target.workspaceId && keyWorkspaceId && keyWorkspaceId !== target.workspaceId) continue;
+      if (keyDirectory === directory) matches.push({ projectKey, connection });
+    }
+    return matches.length === 1 ? matches[0] : null;
   }
 
   getQuestionProjectKey(requestId) {

--- a/server/services/harness-interactions.ts
+++ b/server/services/harness-interactions.ts
@@ -20,11 +20,13 @@ export async function replyToHarnessQuestion(input: {
   harnessId: HarnessId;
   requestId: string;
   answers: QuestionAnswer[];
+  target?: { directory?: string; workspaceId?: string };
 }): Promise<void> {
   await input.services.harnesses.replyQuestion({
     harnessId: input.harnessId,
     requestId: input.requestId,
     answers: input.answers,
+    target: input.target,
   });
 }
 
@@ -32,9 +34,11 @@ export async function rejectHarnessQuestion(input: {
   services: BackendServiceContext;
   harnessId: HarnessId;
   requestId: string;
+  target?: { directory?: string; workspaceId?: string };
 }): Promise<void> {
   await input.services.harnesses.rejectQuestion({
     harnessId: input.harnessId,
     requestId: input.requestId,
+    target: input.target,
   });
 }

--- a/server/services/harness-service.ts
+++ b/server/services/harness-service.ts
@@ -22,6 +22,7 @@ export interface HarnessControl {
 
 export interface HarnessTarget {
   directory?: string;
+  workspaceId?: string;
 }
 
 export interface ProjectConnectionConfig {
@@ -29,6 +30,7 @@ export interface ProjectConnectionConfig {
   username?: string;
   password?: string;
   directory?: string;
+  workspaceId?: string;
 }
 
 export interface HarnessScope {
@@ -36,6 +38,7 @@ export interface HarnessScope {
   sessionId?: string;
   harnessId: HarnessId;
   directory: string;
+  workspaceId?: string;
 }
 
 export class HarnessService {
@@ -75,7 +78,7 @@ export class HarnessService {
 
   async connectProject(input: {
     project: ProjectRecord;
-    scope: Pick<HarnessScope, "projectId" | "directory">;
+    scope: Pick<HarnessScope, "projectId" | "directory" | "workspaceId">;
     harnessIds?: HarnessId[];
     config?: ProjectConnectionConfig;
   }): Promise<ProjectConnectResult> {
@@ -86,6 +89,7 @@ export class HarnessService {
           await this.backendRpc(harnessId, "project:add", [
             {
               directory: input.scope.directory,
+              workspaceId: input.config?.workspaceId,
               baseUrl: input.config?.baseUrl,
               username: input.config?.username,
               password: input.config?.password,
@@ -112,19 +116,22 @@ export class HarnessService {
 
   async disconnectProject(input: {
     project: ProjectRecord;
-    scope: Pick<HarnessScope, "projectId" | "directory">;
+    scope: Pick<HarnessScope, "projectId" | "directory" | "workspaceId">;
     harnessIds?: HarnessId[];
   }): Promise<void> {
     await Promise.all(
       this.harnessIdsOrAll(input.harnessIds).map((harnessId) =>
-        this.backendRpc(harnessId, "project:remove", [input.scope.directory, undefined]),
+        this.backendRpc(harnessId, "project:remove", [
+          input.scope.directory,
+          input.scope.workspaceId,
+        ]),
       ),
     );
   }
 
   async getProjectStatus(input: {
     project: ProjectRecord;
-    scope: Pick<HarnessScope, "projectId" | "directory">;
+    scope: Pick<HarnessScope, "projectId" | "directory" | "workspaceId">;
     harnessIds?: HarnessId[];
   }): Promise<
     Record<
@@ -138,7 +145,7 @@ export class HarnessService {
           const statuses = await this.backendRpc<Record<string, { type: string }>>(
             harnessId,
             "session:statuses",
-            [input.scope.directory, undefined],
+            [input.scope.directory, input.scope.workspaceId],
           );
           return [harnessId, { connected: true, statuses }] as const;
         } catch (error) {
@@ -157,7 +164,7 @@ export class HarnessService {
   }
 
   async listProjectSessions(input: {
-    scope: Pick<HarnessScope, "projectId" | "directory">;
+    scope: Pick<HarnessScope, "projectId" | "directory" | "workspaceId">;
     harnessIds: HarnessId[];
   }): Promise<Array<{ harnessId: HarnessId; sessions: HarnessProjectSessionsResult["sessions"] }>> {
     const results = await Promise.all(
@@ -166,7 +173,7 @@ export class HarnessService {
           const sessions = await this.backendRpc<HarnessProjectSessionsResult["sessions"]>(
             harnessId,
             "session:list",
-            [input.scope.directory, undefined],
+            [input.scope.directory, input.scope.workspaceId],
           );
           return { harnessId: harnessId, sessions };
         } catch {
@@ -286,12 +293,26 @@ export class HarnessService {
     harnessId: HarnessId;
     requestId: string;
     answers: QuestionAnswer[];
+    target?: HarnessTarget;
   }): Promise<void> {
-    await this.backendRpc(input.harnessId, "question:reply", [input.requestId, input.answers]);
+    await this.backendRpc(input.harnessId, "question:reply", [
+      input.requestId,
+      input.answers,
+      input.target?.directory,
+      input.target?.workspaceId,
+    ]);
   }
 
-  async rejectQuestion(input: { harnessId: HarnessId; requestId: string }): Promise<void> {
-    await this.backendRpc(input.harnessId, "question:reject", [input.requestId]);
+  async rejectQuestion(input: {
+    harnessId: HarnessId;
+    requestId: string;
+    target?: HarnessTarget;
+  }): Promise<void> {
+    await this.backendRpc(input.harnessId, "question:reject", [
+      input.requestId,
+      input.target?.directory,
+      input.target?.workspaceId,
+    ]);
   }
 
   async forkSession(input: {

--- a/server/services/http-input.ts
+++ b/server/services/http-input.ts
@@ -43,10 +43,16 @@ export function toQueueMode(value: unknown, fallback?: QueueMode): QueueMode | u
 }
 
 export function toQuestionAnswers(value: unknown): QuestionAnswer[] {
-  return Array.isArray(value)
-    ? (value.filter(
-        (item): item is Record<string, unknown> =>
-          !!item && typeof item === "object" && !Array.isArray(item),
-      ) as unknown as QuestionAnswer[])
-    : [];
+  if (!Array.isArray(value)) return [];
+  return value.map((answer, answerIndex) => {
+    if (!Array.isArray(answer)) {
+      throw new Error(`answers[${answerIndex}] must be an array`);
+    }
+    return answer.map((item, itemIndex) => {
+      if (typeof item !== "string") {
+        throw new Error(`answers[${answerIndex}][${itemIndex}] must be a string`);
+      }
+      return item.trim();
+    });
+  });
 }

--- a/server/services/session-query.ts
+++ b/server/services/session-query.ts
@@ -9,6 +9,7 @@ export interface ResolvedSessionQueryProject {
   frontendProjectId: string;
   directory: string;
   canonicalPath: string;
+  workspaceId?: string;
 }
 
 export async function querySessionsForResolvedProjects(input: {
@@ -17,37 +18,42 @@ export async function querySessionsForResolvedProjects(input: {
   harnessIds: HarnessId[];
   sync: boolean;
 }) {
-  const sessionJobs = input.projects.flatMap(({ frontendProjectId, directory, canonicalPath }) =>
-    input.harnessIds.map((harnessId) => async () => {
-      try {
-        const page = input.sync
-          ? await syncDirectorySessions(input.services, { directory, canonicalPath }, harnessId)
-          : await listSessionRecords({
-              services: input.services,
-              projectId: canonicalPath,
+  const sessionJobs = input.projects.flatMap(
+    ({ frontendProjectId, directory, canonicalPath, workspaceId }) =>
+      input.harnessIds.map((harnessId) => async () => {
+        try {
+          const page = input.sync
+            ? await syncDirectorySessions(
+                input.services,
+                { directory, canonicalPath, workspaceId },
+                harnessId,
+              )
+            : await listSessionRecords({
+                services: input.services,
+                projectId: canonicalPath,
+                harnessId,
+              });
+          return {
+            ok: true as const,
+            item: {
+              frontendProjectId,
+              directory,
               harnessId,
-            });
-        return {
-          ok: true as const,
-          item: {
-            frontendProjectId,
-            directory,
-            harnessId,
-            sessions: page.sessions,
-          },
-        };
-      } catch (error) {
-        return {
-          ok: false as const,
-          error: {
-            frontendProjectId,
-            directory,
-            harnessId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        };
-      }
-    }),
+              sessions: page.sessions,
+            },
+          };
+        } catch (error) {
+          return {
+            ok: false as const,
+            error: {
+              frontendProjectId,
+              directory,
+              harnessId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          };
+        }
+      }),
   );
 
   const sessionResults = await runJobsWithConcurrency(sessionJobs, 4);

--- a/server/services/session-sync.ts
+++ b/server/services/session-sync.ts
@@ -6,6 +6,7 @@ import { toSessionRecordInputFromRuntime } from "./runtime-session-mapper.ts";
 export interface ResolvedHarnessDirectory {
   directory: string;
   canonicalPath: string;
+  workspaceId?: string;
 }
 
 export async function syncDirectorySessions(
@@ -15,7 +16,11 @@ export async function syncDirectorySessions(
 ): Promise<{ sessions: SessionRecord[]; nextCursor: null }> {
   const projectId = directory.canonicalPath;
   const runtimeResults = await services.harnesses.listProjectSessions({
-    scope: { projectId, directory: directory.canonicalPath },
+    scope: {
+      projectId,
+      directory: directory.canonicalPath,
+      workspaceId: directory.workspaceId,
+    },
     harnessIds: [harnessId],
   });
   const runtimeSessions = runtimeResults[0]?.sessions?.filter((session) =>

--- a/server/web-server.ts
+++ b/server/web-server.ts
@@ -1360,11 +1360,18 @@ async function handleQuestionRequest(request: Request) {
     }
     const target = directory ? { directory, workspaceId } : undefined;
     if (action === "reply") {
+      if (!isPlainObject(body) || body.answers === undefined) {
+        throw new Error("answers is required for question reply");
+      }
+      const answers = toQuestionAnswers(body.answers);
+      if (answers.length === 0) {
+        throw new Error("answers must be a non-empty array");
+      }
       await replyToHarnessQuestion({
         services,
         harnessId,
         requestId: questionId,
-        answers: isPlainObject(body) ? toQuestionAnswers(body.answers) : [],
+        answers,
         target,
       });
     } else {

--- a/server/web-server.ts
+++ b/server/web-server.ts
@@ -872,11 +872,12 @@ async function handleSessionRequest(request: Request) {
             "frontendProjectId",
           );
           const directory = toOptionalString(projectInput.directory, "directory");
+          const workspaceId = toOptionalString(projectInput.workspaceId, "workspaceId");
           if (!frontendProjectId || !directory) return null;
 
           try {
             const resolvedDirectory = await resolveHarnessDirectoryForSessions({ directory });
-            return { ok: true as const, frontendProjectId, ...resolvedDirectory };
+            return { ok: true as const, frontendProjectId, workspaceId, ...resolvedDirectory };
           } catch (error) {
             return {
               ok: false as const,
@@ -899,10 +900,11 @@ async function handleSessionRequest(request: Request) {
         .filter((result): result is Extract<NonNullable<typeof result>, { ok: true }> =>
           Boolean(result && result.ok),
         )
-        .map(({ frontendProjectId, directory, canonicalPath }) => ({
+        .map(({ frontendProjectId, directory, canonicalPath, workspaceId }) => ({
           frontendProjectId,
           directory,
           canonicalPath,
+          workspaceId,
         }));
       const queried = await querySessionsForResolvedProjects({
         services,
@@ -1335,15 +1337,38 @@ async function handleQuestionRequest(request: Request) {
         ? (toOptionalString(body.harnessId, "harnessId") ?? "opencode")
         : "opencode"
     ) as HarnessId;
+    const sessionId = isPlainObject(body)
+      ? toOptionalString(body.sessionId, "sessionId")
+      : undefined;
+    const workspaceId = isPlainObject(body)
+      ? toOptionalString(body.workspaceId, "workspaceId")
+      : undefined;
+    const projectId = isPlainObject(body)
+      ? toOptionalString(body.projectId, "projectId")
+      : undefined;
+    const bodyDirectory = isPlainObject(body)
+      ? toOptionalString(body.directory, "directory")
+      : undefined;
+    let directory = bodyDirectory;
+    if (!directory && sessionId) {
+      const session = await getSessionOrThrow(services, sessionId, {
+        harnessId,
+      });
+      directory = (await getSessionProjectScopeOrThrow(services, session)).path;
+    } else if (!directory && projectId) {
+      directory = (await getProjectOrThrow(services, projectId)).path;
+    }
+    const target = directory ? { directory, workspaceId } : undefined;
     if (action === "reply") {
       await replyToHarnessQuestion({
         services,
         harnessId,
         requestId: questionId,
         answers: isPlainObject(body) ? toQuestionAnswers(body.answers) : [],
+        target,
       });
     } else {
-      await rejectHarnessQuestion({ services, harnessId, requestId: questionId });
+      await rejectHarnessQuestion({ services, harnessId, requestId: questionId, target });
     }
     return Response.json({ ok: true, value: true });
   } catch (error) {

--- a/src/agents/protocol/opencode-map.test.ts
+++ b/src/agents/protocol/opencode-map.test.ts
@@ -77,6 +77,29 @@ describe("mapOpenCodeEvent", () => {
     });
   });
 
+  test("maps sync question replies", () => {
+    expect(
+      mapOpenCodeEvent(
+        {
+          type: "sync",
+          syncEvent: {
+            id: "event-2",
+            type: "question.replied.0",
+            data: {
+              sessionID: "session-1",
+              requestID: "question-1",
+              answers: [["Yes"]],
+            },
+          },
+        },
+        context,
+      ),
+    ).toEqual({
+      type: "question.cleared",
+      sessionID: "opencode:session-1",
+    });
+  });
+
   test("returns null for unhandled and aborted error events", () => {
     expect(
       mapOpenCodeEvent(

--- a/src/agents/shared.test.ts
+++ b/src/agents/shared.test.ts
@@ -65,6 +65,27 @@ describe("normalizeTaggedBackendEvent", () => {
     });
   });
 
+  test("keeps a session-owned directory when it differs from the event target", () => {
+    const event = {
+      type: "opencode:event",
+      payload: {
+        type: "session.created",
+        directory: "/pictures",
+        workspaceId: "workspace-1",
+        session: { ...session, directory: "/documents" },
+      },
+    } as unknown as NativeBackendEvent;
+
+    const normalized = normalizeTaggedBackendEvent("opencode", event, "opencode:event");
+
+    expect(normalized).toMatchObject({
+      type: "session.created",
+      session: {
+        _projectDir: "/documents",
+      },
+    });
+  });
+
   test("prefixes ids in non-session payloads", () => {
     const event = {
       type: "claude-code:event",

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -40,7 +40,7 @@ export function tagBackendSession(
   target?: { directory?: string; workspaceId?: string },
 ): TaggedSession {
   const rawId = session._rawId ?? session.id;
-  const projectDir = target?.directory ?? session._projectDir ?? session.directory;
+  const projectDir = session.directory ?? session._projectDir ?? target?.directory;
   return {
     ...session,
     id: createBackendIdCodec(harnessId).compose(rawId),

--- a/src/components/message-list/QuestionPanel.tsx
+++ b/src/components/message-list/QuestionPanel.tsx
@@ -1,6 +1,7 @@
 import type { QuestionAnswer, QuestionInfo } from "@opencode-ai/sdk/v2/client";
 import { Check, MessageCircleQuestion, X } from "lucide-react";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -13,6 +14,7 @@ export function QuestionPanel({
   onSubmit: (answers: QuestionAnswer[]) => void;
   onDismiss: () => void;
 }) {
+  const { t } = useTranslation();
   const [selections, setSelections] = useState<string[][]>(() => questions.map(() => []));
   const [customTexts, setCustomTexts] = useState<string[]>(() => questions.map(() => ""));
 
@@ -48,14 +50,16 @@ export function QuestionPanel({
     onSubmit(answers);
   }, [questions, selections, customTexts, onSubmit]);
 
-  const hasAnyAnswer =
-    selections.some((s) => s.length > 0) || customTexts.some((t) => t.trim().length > 0);
+  const hasAllAnswers = questions.every(
+    (_q, qIdx) =>
+      (selections[qIdx]?.length ?? 0) > 0 || (customTexts[qIdx] ?? "").trim().length > 0,
+  );
 
   return (
     <div className="border rounded-lg p-4 bg-primary/5 border-primary/20 space-y-4">
       <div className="flex items-start gap-2">
         <MessageCircleQuestion className="size-5 text-primary shrink-0 mt-0.5" />
-        <span className="text-sm font-medium">The assistant has a question</span>
+        <span className="text-sm font-medium">{t("questionPanel.title")}</span>
       </div>
 
       {questions.map((q, qIdx) => {
@@ -95,11 +99,11 @@ export function QuestionPanel({
             {allowCustom && (
               <input
                 type="text"
-                placeholder="Type a custom answer..."
+                placeholder={t("questionPanel.customAnswerPlaceholder")}
                 value={customTexts[qIdx] ?? ""}
                 onChange={(e) => handleCustomTextChange(qIdx, e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && hasAnyAnswer) {
+                  if (e.key === "Enter" && hasAllAnswers) {
                     e.preventDefault();
                     handleSubmit();
                   }
@@ -112,12 +116,12 @@ export function QuestionPanel({
       })}
 
       <div className="flex gap-2 pt-1">
-        <Button size="sm" variant="default" disabled={!hasAnyAnswer} onClick={handleSubmit}>
-          Submit
+        <Button size="sm" variant="default" disabled={!hasAllAnswers} onClick={handleSubmit}>
+          {t("questionPanel.submit")}
         </Button>
         <Button size="sm" variant="ghost" onClick={onDismiss}>
           <X className="size-3.5 mr-1" />
-          Dismiss
+          {t("questionPanel.dismiss")}
         </Button>
       </div>
     </div>

--- a/src/hooks/use-agent-impl-core.tsx
+++ b/src/hooks/use-agent-impl-core.tsx
@@ -1269,7 +1269,7 @@ function InternalAgentProvider({
         if (getSessionWorkspaceId(session)) {
           return getSessionWorkspaceId(session) === activeWorkspace.id;
         }
-        const directory = session._projectDir ?? session.directory;
+        const directory = normalizeProjectPath((session._projectDir ?? session.directory) || "");
         return activeWorkspaceProjectSet.has(directory);
       }),
     [state.sessions, state.sessionMeta, activeWorkspace, activeWorkspaceProjectSet],
@@ -2039,11 +2039,18 @@ function InternalAgentProvider({
       if (!state.activeSessionId) return;
       const pending = state.pendingQuestions[state.activeSessionId];
       if (!pending) return;
+      const session = state.sessions.find((item) => item.id === state.activeSessionId);
       try {
         await openGuiClient.sessions.replyQuestion({
+          sessionId: state.activeSessionId,
           requestId: pending.id,
           answers,
-          harnessId: activeSessionBackendId ?? undefined,
+          harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
+          target: getSessionProjectTarget(session) ?? undefined,
+        });
+        dispatch({
+          type: "SET_QUESTION",
+          payload: { sessionID: state.activeSessionId, clear: true },
         });
       } catch (error) {
         dispatch({
@@ -2052,17 +2059,24 @@ function InternalAgentProvider({
         });
       }
     },
-    [activeSessionBackendId, openGuiClient, state.pendingQuestions, state.activeSessionId],
+    [openGuiClient, state.pendingQuestions, state.activeSessionId, state.sessions],
   );
 
   const rejectQuestion = useCallback(async () => {
     if (!state.activeSessionId) return;
     const pending = state.pendingQuestions[state.activeSessionId];
     if (!pending) return;
+    const session = state.sessions.find((item) => item.id === state.activeSessionId);
     try {
       await openGuiClient.sessions.rejectQuestion({
+        sessionId: state.activeSessionId,
         requestId: pending.id,
-        harnessId: activeSessionBackendId ?? undefined,
+        harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
+        target: getSessionProjectTarget(session) ?? undefined,
+      });
+      dispatch({
+        type: "SET_QUESTION",
+        payload: { sessionID: state.activeSessionId, clear: true },
       });
     } catch (error) {
       dispatch({
@@ -2070,7 +2084,7 @@ function InternalAgentProvider({
         payload: error instanceof Error ? error.message : "Failed to dismiss question",
       });
     }
-  }, [activeSessionBackendId, openGuiClient, state.pendingQuestions, state.activeSessionId]);
+  }, [openGuiClient, state.pendingQuestions, state.activeSessionId, state.sessions]);
 
   const setDefaultChatDirectory = useCallback((directory: string | null) => {
     const normalizedDirectory = directory ? normalizeProjectPath(directory) : null;
@@ -2691,7 +2705,9 @@ function InternalAgentProvider({
             if (sessionWorkspaceId) {
               return sessionWorkspaceId === workspace.id;
             }
-            const directory = session._projectDir ?? session.directory;
+            const directory = normalizeProjectPath(
+              (session._projectDir ?? session.directory) || "",
+            );
             return workspace.projects.includes(directory);
           });
           const sessionIds = new Set(workspaceSessions.map((session) => session.id));

--- a/src/lib/__tests__/path.test.ts
+++ b/src/lib/__tests__/path.test.ts
@@ -4,14 +4,21 @@ import { getProjectName, normalizeProjectPath } from "../path";
 describe("normalizeProjectPath", () => {
   test("trims whitespace and trailing separators", () => {
     expect(normalizeProjectPath("  /repo/project///  ")).toBe("/repo/project");
-    expect(normalizeProjectPath("C:\\repo\\project\\")).toBe("C:\\repo\\project");
+    expect(normalizeProjectPath("C:\\repo\\project\\")).toBe("C:/repo/project");
+  });
+
+  test("canonicalizes Windows separators", () => {
+    expect(normalizeProjectPath("C:\\Users\\Quickemu\\Documents")).toBe(
+      "C:/Users/Quickemu/Documents",
+    );
+    expect(normalizeProjectPath("C:/Users/Quickemu/Documents")).toBe("C:/Users/Quickemu/Documents");
   });
 
   test("preserves filesystem roots", () => {
     expect(normalizeProjectPath("/")).toBe("/");
-    expect(normalizeProjectPath("\\\\")).toBe("\\");
+    expect(normalizeProjectPath("\\\\")).toBe("/");
     expect(normalizeProjectPath("C:/")).toBe("C:/");
-    expect(normalizeProjectPath("C:\\")).toBe("C:\\");
+    expect(normalizeProjectPath("C:\\")).toBe("C:/");
   });
 
   test("returns empty strings for blank paths", () => {

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -1,13 +1,13 @@
 /** Normalize project path for stable workspace/session keys. */
 export function normalizeProjectPath(path: string): string {
-  const trimmed = path.trim();
+  const trimmed = path.trim().replace(/\\/g, "/");
   if (!trimmed) return "";
-  if (/^[/\\]+$/.test(trimmed)) return trimmed[0] ?? trimmed;
-  const windowsDriveRoot = trimmed.match(/^([A-Za-z]:)([/\\]+)$/);
+  if (/^\/+$/.test(trimmed)) return "/";
+  const windowsDriveRoot = trimmed.match(new RegExp("^([A-Za-z]:)(/+)$"));
   if (windowsDriveRoot) {
-    return `${windowsDriveRoot[1]}${trimmed.includes("\\") ? "\\" : "/"}`;
+    return `${windowsDriveRoot[1]}/`;
   }
-  return trimmed.replace(/[/\\]+$/, "");
+  return trimmed.replace(/\/+$/, "");
 }
 
 /** Extract the trailing directory name from an absolute path (cross-platform). */

--- a/src/protocol/client.ts
+++ b/src/protocol/client.ts
@@ -226,11 +226,18 @@ export interface OpenGuiClient {
       target?: HarnessTarget;
     }): Promise<void>;
     replyQuestion(input: {
+      sessionId?: string;
       requestId: string;
       answers: QuestionAnswer[];
       harnessId?: HarnessId;
+      target?: HarnessTarget;
     }): Promise<void>;
-    rejectQuestion(input: { requestId: string; harnessId?: HarnessId }): Promise<void>;
+    rejectQuestion(input: {
+      sessionId?: string;
+      requestId: string;
+      harnessId?: HarnessId;
+      target?: HarnessTarget;
+    }): Promise<void>;
     queue: {
       list(
         input: QueueScopeInput & {

--- a/src/protocol/http-client.test.ts
+++ b/src/protocol/http-client.test.ts
@@ -303,6 +303,57 @@ describe("createHttpOpenGuiClient", () => {
     });
   });
 
+  test("sends session and project context with question replies", async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const client = createHttpOpenGuiClient({
+      baseUrl: "http://example.test",
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+        calls.push({ url, body });
+        if (url.endsWith("/api/projects") && (!init?.method || init.method === "GET")) {
+          return json({
+            ok: true,
+            value: [
+              {
+                id: "project_1",
+                displayName: "repo",
+                path: "/repo",
+                canonicalPath: "/repo",
+                createdAt: "2026-05-12T00:00:00.000Z",
+                updatedAt: "2026-05-12T00:00:00.000Z",
+              },
+            ],
+          });
+        }
+        if (url.endsWith("/api/questions/question_1/reply") && init?.method === "POST") {
+          return json({ ok: true, value: true });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      },
+    });
+
+    await client.sessions.replyQuestion({
+      sessionId: "opencode:session_1",
+      requestId: "question_1",
+      answers: [["Yes"]],
+      harnessId: "opencode",
+      target: { directory: "/repo", workspaceId: "workspace-1" },
+    });
+
+    expect(calls.at(-1)).toEqual({
+      url: "http://example.test/api/questions/question_1/reply",
+      body: {
+        sessionId: "opencode:session_1",
+        answers: [["Yes"]],
+        harnessId: "opencode",
+        workspaceId: "workspace-1",
+        projectId: "project_1",
+        directory: "/repo",
+      },
+    });
+  });
+
   test("sends auth token with RPC requests", async () => {
     const originalFetch = globalThis.fetch;
     let authHeader = "";

--- a/src/protocol/http-client.test.ts
+++ b/src/protocol/http-client.test.ts
@@ -304,13 +304,14 @@ describe("createHttpOpenGuiClient", () => {
   });
 
   test("sends session and project context with question replies", async () => {
-    const calls: Array<{ url: string; body: unknown }> = [];
+    const calls: Array<{ url: string; method: string; body: unknown }> = [];
     const client = createHttpOpenGuiClient({
       baseUrl: "http://example.test",
       fetchImpl: async (input, init) => {
         const url = String(input);
+        const method = init?.method ?? "GET";
         const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
-        calls.push({ url, body });
+        calls.push({ url, method, body });
         if (url.endsWith("/api/projects") && (!init?.method || init.method === "GET")) {
           return json({
             ok: true,
@@ -343,6 +344,7 @@ describe("createHttpOpenGuiClient", () => {
 
     expect(calls.at(-1)).toEqual({
       url: "http://example.test/api/questions/question_1/reply",
+      method: "POST",
       body: {
         sessionId: "opencode:session_1",
         answers: [["Yes"]],
@@ -351,6 +353,46 @@ describe("createHttpOpenGuiClient", () => {
         projectId: "project_1",
         directory: "/repo",
       },
+    });
+  });
+
+  test("does not create project records for question replies", async () => {
+    const calls: Array<{ url: string; method: string; body: unknown }> = [];
+    const client = createHttpOpenGuiClient({
+      baseUrl: "http://example.test",
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+        calls.push({ url, method, body });
+        if (url.endsWith("/api/projects") && method === "GET") {
+          return json({ ok: true, value: [] });
+        }
+        if (url.endsWith("/api/questions/question_1/reply") && method === "POST") {
+          return json({ ok: true, value: true });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      },
+    });
+
+    await client.sessions.replyQuestion({
+      sessionId: "opencode:session_1",
+      requestId: "question_1",
+      answers: [["Yes"]],
+      harnessId: "opencode",
+      target: { directory: "/untracked", workspaceId: "workspace-1" },
+    });
+
+    expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
+      "GET http://example.test/api/projects",
+      "POST http://example.test/api/questions/question_1/reply",
+    ]);
+    expect(calls.at(-1)?.body).toEqual({
+      sessionId: "opencode:session_1",
+      answers: [["Yes"]],
+      harnessId: "opencode",
+      workspaceId: "workspace-1",
+      directory: "/untracked",
     });
   });
 

--- a/src/protocol/http-client.ts
+++ b/src/protocol/http-client.ts
@@ -1083,17 +1083,40 @@ export function createHttpOpenGuiClient(options: HttpOpenGuiClientOptions = {}):
           },
         );
       },
-      replyQuestion: async ({ requestId, answers, harnessId }) => {
-        await request<boolean>(`/api/questions/${encodeURIComponent(requestId)}/reply`, {
-          method: "POST",
-          body: JSON.stringify({ answers, harnessId }),
-        });
+      replyQuestion: async ({ sessionId, requestId, answers, harnessId, target }) => {
+        const project = target ? await ensureProjectForTarget(target) : null;
+        await requestAt<boolean>(
+          requestBaseUrlForTarget(target),
+          `/api/questions/${encodeURIComponent(requestId)}/reply`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              sessionId,
+              answers,
+              harnessId,
+              workspaceId: project?.workspaceId ?? target?.workspaceId,
+              projectId: project?.id,
+              directory: target?.directory,
+            }),
+          },
+        );
       },
-      rejectQuestion: async ({ requestId, harnessId }) => {
-        await request<boolean>(`/api/questions/${encodeURIComponent(requestId)}/reject`, {
-          method: "POST",
-          body: JSON.stringify({ harnessId }),
-        });
+      rejectQuestion: async ({ sessionId, requestId, harnessId, target }) => {
+        const project = target ? await ensureProjectForTarget(target) : null;
+        await requestAt<boolean>(
+          requestBaseUrlForTarget(target),
+          `/api/questions/${encodeURIComponent(requestId)}/reject`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              sessionId,
+              harnessId,
+              workspaceId: project?.workspaceId ?? target?.workspaceId,
+              projectId: project?.id,
+              directory: target?.directory,
+            }),
+          },
+        );
       },
       queue: {
         list: async ({ sessionId, harnessId, target }) =>

--- a/src/protocol/http-client.ts
+++ b/src/protocol/http-client.ts
@@ -1084,7 +1084,7 @@ export function createHttpOpenGuiClient(options: HttpOpenGuiClientOptions = {}):
         );
       },
       replyQuestion: async ({ sessionId, requestId, answers, harnessId, target }) => {
-        const project = target ? await ensureProjectForTarget(target) : null;
+        const project = target ? await findProjectForTarget(target) : null;
         await requestAt<boolean>(
           requestBaseUrlForTarget(target),
           `/api/questions/${encodeURIComponent(requestId)}/reply`,
@@ -1102,7 +1102,7 @@ export function createHttpOpenGuiClient(options: HttpOpenGuiClientOptions = {}):
         );
       },
       rejectQuestion: async ({ sessionId, requestId, harnessId, target }) => {
-        const project = target ? await ensureProjectForTarget(target) : null;
+        const project = target ? await findProjectForTarget(target) : null;
         await requestAt<boolean>(
           requestBaseUrlForTarget(target),
           `/api/questions/${encodeURIComponent(requestId)}/reject`,

--- a/src/server-http-input.test.ts
+++ b/src/server-http-input.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import { toQuestionAnswers } from "../server/services/http-input";
+
+describe("toQuestionAnswers", () => {
+  test("preserves OpenCode question answer arrays", () => {
+    expect(
+      toQuestionAnswers([
+        ["20.000-35.000 €"],
+        ["Diesel"],
+        ["15.000-25.000 km"],
+        ["Zuverlässigkeit", "Komfort"],
+      ]),
+    ).toEqual([
+      ["20.000-35.000 €"],
+      ["Diesel"],
+      ["15.000-25.000 km"],
+      ["Zuverlässigkeit", "Komfort"],
+    ]);
+  });
+
+  test("rejects malformed question answers", () => {
+    expect(() => toQuestionAnswers([{ answer: "Diesel" }])).toThrow("answers[0] must be an array");
+    expect(() => toQuestionAnswers([["Diesel", 123]])).toThrow("answers[0][1] must be a string");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve OpenCode question answer arrays instead of dropping string[][] payloads
- route question reply/reject calls with session/project/workspace context so they reach the owning OpenCode connection
- clear pending questions after successful reply/reject and keep sync question events flowing

## Verification
- vp test src/server-http-input.test.ts src/protocol/http-client.test.ts src/agents/protocol/opencode-map.test.ts src/agents/shared.test.ts src/lib/__tests__/path.test.ts
- vp check (passes with existing pi-bridge.ts await-thenable warnings)