### PR TITLE
Fix OpenCode permission responses

### DIFF
--- a/opencode-bridge.ts
+++ b/opencode-bridge.ts
@@ -255,6 +255,28 @@ function tagOpenCodeMessageEntry(entry) {
 const httpAgent = new Agent({ keepAlive: true, keepAliveMsecs: 15_000 });
 const httpsAgent = new HttpsAgent({ keepAlive: true, keepAliveMsecs: 15_000 });
 
+function assertOpenCodeResponseOk(result, fallbackMessage) {
+  if (!result || typeof result !== "object") return result;
+  if (result.error) {
+    const message =
+      typeof result.error.message === "string" && result.error.message.trim()
+        ? result.error.message
+        : fallbackMessage;
+    const error = new Error(message);
+    error.status = result.response?.status;
+    error.data = result.error;
+    throw error;
+  }
+  if (result.response && result.response.ok === false) {
+    const error = new Error(
+      `${fallbackMessage}: ${result.response.status} ${result.response.statusText}`,
+    );
+    error.status = result.response.status;
+    throw error;
+  }
+  return result;
+}
+
 function stripMessagePayloadBloat(messages) {
   for (const message of messages) {
     const summary = message?.info?.summary;
@@ -542,13 +564,41 @@ export class OpenCodeConnection {
 
   // - permissions ----------------------------------------------------------
 
-  async respondPermission(sessionId, permissionId, response) {
+  async respondPermission(sessionId, permissionId, response, workspaceId) {
     this._requireClient();
-    await this._client.permission.respond({
-      sessionID: sessionId,
-      permissionID: permissionId,
-      response,
-    });
+    const directory = this.getDirectory();
+    const workspace =
+      typeof workspaceId === "string" && workspaceId.trim() && workspaceId !== "local"
+        ? workspaceId.trim()
+        : undefined;
+    try {
+      assertOpenCodeResponseOk(
+        await this._client.permission.reply({
+          requestID: permissionId,
+          reply: response,
+          ...(directory ? { directory } : {}),
+          ...(workspace ? { workspace } : {}),
+        }),
+        `Permission reply failed for ${permissionId}`,
+      );
+    } catch (replyError) {
+      // Fallback for older OpenCode servers which only expose deprecated
+      // session-scoped permission responses.
+      try {
+        assertOpenCodeResponseOk(
+          await this._client.permission.respond({
+            sessionID: sessionId,
+            permissionID: permissionId,
+            response,
+            ...(directory ? { directory } : {}),
+            ...(workspace ? { workspace } : {}),
+          }),
+          `Permission response failed for ${permissionId}`,
+        );
+      } catch {
+        throw replyError;
+      }
+    }
   }
 
   // - commands -------------------------------------------------------------
@@ -1914,8 +1964,10 @@ export function setupOpenCodeBridge(ipcMain, _getWindows) {
 
   // --- Permission response (routed to session's connection) ---
 
-  handleSessionOp("opencode:permission", (conn, sessionId, permissionId, response) =>
-    conn.respondPermission(sessionId, permissionId, response),
+  handleSessionOp(
+    "opencode:permission",
+    (conn, sessionId, permissionId, response, directory, workspaceId) =>
+      conn.respondPermission(sessionId, permissionId, response, workspaceId),
   );
 
   // --- Question response (target/question routed) ---

--- a/scripts/diagnose-permission-response.mjs
+++ b/scripts/diagnose-permission-response.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const key = process.argv[i];
+  if (!key?.startsWith("--")) continue;
+  args.set(key.slice(2), process.argv[i + 1]?.startsWith("--") ? "" : (process.argv[++i] ?? ""));
+}
+
+const projectDir = args.get("project-dir") || process.env.PROJECT_DIR || process.cwd();
+const opencodeBase = args.get("opencode") || process.env.OPENCODE_BASE || "http://127.0.0.1:4096";
+const fakePermissionId = args.get("fake-permission") || "per_fake_diagnostic";
+
+function findSidecar() {
+  const ps = execFileSync("ps", ["-eww", "-o", "pid=,args="], { encoding: "utf8" });
+  const candidates = ps
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes("backend.js"))
+    .map((line) => Number.parseInt(line.split(/\s+/, 1)[0] ?? "", 10))
+    .filter(Number.isFinite);
+  for (const pid of candidates.reverse()) {
+    try {
+      const env = Object.fromEntries(
+        readFileSync(`/proc/${pid}/environ`, "utf8")
+          .split("\0")
+          .filter(Boolean)
+          .map((entry) => {
+            const idx = entry.indexOf("=");
+            return [entry.slice(0, idx), entry.slice(idx + 1)];
+          }),
+      );
+      if (env.PORT && env.OPENGUI_AUTH_TOKEN) {
+        return {
+          base: `http://${env.HOST || "127.0.0.1"}:${env.PORT}`,
+          token: env.OPENGUI_AUTH_TOKEN,
+        };
+      }
+    } catch {
+      // ignore inaccessible process
+    }
+  }
+  return null;
+}
+
+const sidecar = findSidecar();
+const openGuiBase = args.get("opengui") || process.env.OPENGUI_BASE || sidecar?.base;
+const token = args.get("token") || process.env.OPENGUI_TOKEN || sidecar?.token;
+if (!openGuiBase || !token) {
+  console.error("Missing OpenGUI base/token. Pass --opengui http://127.0.0.1:PORT --token TOKEN");
+  process.exit(2);
+}
+
+async function jsonFetch(url, init = {}) {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { status: res.status, ok: res.ok, body };
+}
+
+async function openGui(path, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set("authorization", `Bearer ${token}`);
+  if (init.body && !headers.has("content-type")) headers.set("content-type", "application/json");
+  return jsonFetch(`${openGuiBase.replace(/\/+$/, "")}${path}`, { ...init, headers });
+}
+
+async function main() {
+  console.log(`OpenGUI: ${openGuiBase}`);
+  console.log(`OpenCode: ${opencodeBase}`);
+  console.log(`Project dir: ${projectDir}`);
+
+  const health = await openGui("/api/health");
+  console.log("health", health.status, health.body);
+
+  const ocHealth = await jsonFetch(`${opencodeBase}/global/health`);
+  console.log("opencode health", ocHealth.status, ocHealth.body);
+
+  const projects = await openGui("/api/projects");
+  const project = projects.body?.value?.find?.(
+    (item) => item.path === projectDir || item.canonicalPath === projectDir,
+  );
+  if (!project) throw new Error(`Project not found for ${projectDir}`);
+  console.log("project", { id: project.id, path: project.path });
+
+  const sessions = await openGui(
+    `/api/sessions?projectId=${encodeURIComponent(project.id)}&harnessId=opencode`,
+  );
+  const session =
+    sessions.body?.value?.sessions?.find?.((item) => item.status === "running") ??
+    sessions.body?.value?.sessions?.[0];
+  if (!session) throw new Error(`No opencode sessions for ${project.id}`);
+  const frontendSessionId = `opencode:${session.rawId}`;
+  console.log("session", { rawId: session.rawId, status: session.status, frontendSessionId });
+
+  const legacyPending = await jsonFetch(
+    `${opencodeBase}/permission?directory=${encodeURIComponent(project.path)}`,
+  );
+  console.log("opencode legacy pending", legacyPending.status, legacyPending.body);
+
+  const apiPermission = await openGui(`/api/permissions/${fakePermissionId}/respond`, {
+    method: "POST",
+    body: JSON.stringify({
+      sessionId: frontendSessionId,
+      response: "once",
+      harnessId: "opencode",
+      projectId: project.id,
+    }),
+  });
+  console.log("OpenGUI /api/permissions fake", apiPermission.status, apiPermission.body);
+
+  const rpcNoDir = await openGui("/api/rpc", {
+    method: "POST",
+    body: JSON.stringify({
+      channel: "opencode:permission",
+      args: [session.rawId, fakePermissionId, "once"],
+    }),
+  });
+  console.log("RPC opencode:permission no directory", rpcNoDir.status, rpcNoDir.body);
+
+  const rpcWithDir = await openGui("/api/rpc", {
+    method: "POST",
+    body: JSON.stringify({
+      channel: "opencode:permission",
+      args: [session.rawId, fakePermissionId, "once", project.path, undefined],
+    }),
+  });
+  console.log("RPC opencode:permission with directory", rpcWithDir.status, rpcWithDir.body);
+
+  const noDirError = rpcNoDir.body?.value?.error || rpcNoDir.body?.error;
+  const apiError = apiPermission.body?.error;
+  const withDirOk = rpcWithDir.body?.value?.success === true;
+
+  console.log("\nConclusion:");
+  if (
+    apiError === "Session connection not found" &&
+    noDirError === "Session connection not found" &&
+    withDirOk
+  ) {
+    console.log(
+      "ROOT CAUSE PRESENT: permission responses omit directory/workspace when calling opencode:permission.",
+    );
+    console.log("FIX: pass session project scope directory/workspace through respondPermission.");
+    return;
+  }
+  if (apiPermission.ok && noDirError === "Session connection not found" && withDirOk) {
+    console.log("ROUTE FIXED: /api/permissions now reaches directory-scoped opencode connection.");
+    console.log(
+      "Note: fake permission IDs may still return ok because the SDK does not throw on 404 without throwOnError.",
+    );
+    return;
+  }
+  console.log("Unexpected result. Inspect output above.");
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/services/harness-interactions.ts
+++ b/server/services/harness-interactions.ts
@@ -7,11 +7,13 @@ export async function respondToHarnessPermission(input: {
   session: SessionRecord;
   permissionId: string;
   response: "once" | "always" | "reject";
+  scope?: { directory?: string; workspaceId?: string };
 }): Promise<void> {
   await input.services.harnesses.respondPermission({
     session: input.session,
     permissionId: input.permissionId,
     response: input.response,
+    scope: input.scope,
   });
 }
 

--- a/server/services/harness-service.ts
+++ b/server/services/harness-service.ts
@@ -281,11 +281,14 @@ export class HarnessService {
     session: SessionRecord;
     permissionId: string;
     response: "once" | "always" | "reject";
+    scope?: { directory?: string; workspaceId?: string };
   }): Promise<void> {
     await this.backendRpc(input.session.harnessId, "permission", [
       input.session.rawId,
       input.permissionId,
       input.response,
+      input.scope?.directory,
+      input.scope?.workspaceId,
     ]);
   }
 

--- a/server/web-server.ts
+++ b/server/web-server.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { HarnessEvent } from "../src/agents/backend.ts";
 import type { HarnessId } from "../src/agents/index.ts";
+import { parseFrontendSessionId } from "../src/lib/session-identity.ts";
 import {
   BackendEventBus,
   compactSessionThroughHarness,
@@ -659,6 +660,65 @@ async function getSessionOrThrow(
   }
 }
 
+async function resolvePermissionSessionScope(
+  services: BackendServiceContext,
+  body: Record<string, unknown>,
+): Promise<{ session: SessionRecord; project: ProjectRecord; workspaceId?: string }> {
+  const sessionId = toOptionalString(body.sessionId, "sessionId");
+  if (!sessionId) throw new Error("sessionId and response are required");
+  const harnessId =
+    (toOptionalString(body.harnessId, "harnessId") as HarnessId | undefined) ?? undefined;
+  const projectId = toOptionalString(body.projectId, "projectId") ?? undefined;
+  const directory = toOptionalString(body.directory, "directory") ?? undefined;
+  const workspaceId = toOptionalString(body.workspaceId, "workspaceId") ?? undefined;
+
+  try {
+    const session = await getSessionOrThrow(services, sessionId, { projectId, harnessId });
+    return {
+      session,
+      project: await getSessionProjectScopeOrThrow(services, session),
+      workspaceId:
+        workspaceId ??
+        (session.metadata && typeof session.metadata.workspaceID === "string"
+          ? session.metadata.workspaceID
+          : undefined),
+    };
+  } catch (error) {
+    const frontend = parseFrontendSessionId(sessionId);
+    if (!frontend) throw error;
+    if (harnessId && harnessId !== frontend.harnessId) throw error;
+    if (!projectId && !directory) throw error;
+
+    const fallbackDirectory = directory ?? "";
+    const project = projectId
+      ? await getProjectOrThrow(services, projectId)
+      : await createProjectRecord({
+          services,
+          project: await normalizeProjectCreateInput(
+            { path: fallbackDirectory, displayName: basename(fallbackDirectory) },
+            resolveSafeDirectory,
+            realpath,
+          ),
+        });
+    const now = new Date().toISOString();
+    return {
+      session: {
+        id: sessionId,
+        rawId: frontend.rawId,
+        projectId: project.id,
+        harnessId: frontend.harnessId,
+        title: "Recovered session",
+        status: "unknown",
+        createdAt: now,
+        updatedAt: now,
+        metadata: { directory: project.path, workspaceID: workspaceId, recovered: true },
+      },
+      project,
+      workspaceId,
+    };
+  }
+}
+
 function decodeCanonicalDirectorySessionId(
   sessionId: string,
 ): { projectId: string; harnessId: HarnessId; rawId: string } | null {
@@ -1303,16 +1363,13 @@ async function handlePermissionRequest(request: Request) {
     ) {
       throw new Error("sessionId and response are required");
     }
-    const session = await getSessionOrThrow(services, body.sessionId, {
-      projectId: toOptionalString(body.projectId, "projectId") ?? undefined,
-      harnessId:
-        (toOptionalString(body.harnessId, "harnessId") as HarnessId | undefined) ?? undefined,
-    });
+    const { session, project, workspaceId } = await resolvePermissionSessionScope(services, body);
     await respondToHarnessPermission({
       services,
       session,
       permissionId,
       response: body.response as "once" | "always" | "reject",
+      scope: { directory: project.path, workspaceId },
     });
     return Response.json({ ok: true, value: true });
   } catch (error) {

--- a/src/agents/protocol/opencode-map.test.ts
+++ b/src/agents/protocol/opencode-map.test.ts
@@ -100,6 +100,55 @@ describe("mapOpenCodeEvent", () => {
     });
   });
 
+  test("maps v2 permission requests to panel-compatible shape", () => {
+    expect(
+      mapOpenCodeEvent(
+        {
+          type: "permission.v2.asked",
+          properties: {
+            id: "permission-1",
+            sessionID: "session-1",
+            action: "external_directory",
+            resources: ["/tmp/opengui-uploads/*"],
+            save: ["/tmp/opengui-uploads/*"],
+            metadata: { tool: "read" },
+          },
+        } as unknown as OpenCodeEvent,
+        context,
+      ),
+    ).toEqual({
+      type: "permission.requested",
+      request: {
+        id: "permission-1",
+        sessionID: "opencode:session-1",
+        permission: "external_directory",
+        patterns: ["/tmp/opengui-uploads/*"],
+        always: ["/tmp/opengui-uploads/*"],
+        metadata: { tool: "read" },
+        source: undefined,
+      },
+    });
+  });
+
+  test("maps v2 permission replies", () => {
+    expect(
+      mapOpenCodeEvent(
+        {
+          type: "permission.v2.replied",
+          properties: {
+            sessionID: "session-1",
+            requestID: "permission-1",
+            reply: "once",
+          },
+        } as unknown as OpenCodeEvent,
+        context,
+      ),
+    ).toEqual({
+      type: "permission.cleared",
+      sessionID: "opencode:session-1",
+    });
+  });
+
   test("returns null for unhandled and aborted error events", () => {
     expect(
       mapOpenCodeEvent(

--- a/src/agents/protocol/opencode-map.ts
+++ b/src/agents/protocol/opencode-map.ts
@@ -172,6 +172,38 @@ export const openCodeEventHandlers: Partial<Record<string, OpenCodeEventHandler>
     type: "permission.cleared",
     sessionID: toCompositeSessionId(getSessionId(getProperties(event))),
   }),
+  "permission.v2.asked": (event) => {
+    const properties = getProperties(event) as {
+      id: string;
+      sessionID: string;
+      action: string;
+      resources?: unknown;
+      save?: unknown;
+      metadata?: unknown;
+      source?: unknown;
+    };
+    return {
+      type: "permission.requested",
+      request: {
+        id: properties.id,
+        sessionID: toCompositeSessionId(properties.sessionID),
+        permission: properties.action,
+        patterns: Array.isArray(properties.resources)
+          ? properties.resources.filter((item): item is string => typeof item === "string")
+          : [],
+        always: Array.isArray(properties.save)
+          ? properties.save.filter((item): item is string => typeof item === "string")
+          : [],
+        metadata:
+          properties.metadata && typeof properties.metadata === "object" ? properties.metadata : {},
+        source: properties.source,
+      } as PermissionRequest,
+    };
+  },
+  "permission.v2.replied": (event) => ({
+    type: "permission.cleared",
+    sessionID: toCompositeSessionId(getSessionId(getProperties(event))),
+  }),
   "question.asked": (event) => {
     const properties = getProperties(event) as Record<string, unknown> & { sessionID: string };
     return {

--- a/src/components/PromptBox.tsx
+++ b/src/components/PromptBox.tsx
@@ -416,7 +416,8 @@ export const PromptBox = React.forwardRef<HTMLTextAreaElement, PromptBoxProps>(
               <Button
                 type="button"
                 size="icon-sm"
-                variant="secondary"
+                variant="default"
+                className="bg-primary text-[oklch(0.985_0_0)] hover:bg-primary/85 dark:text-primary-foreground"
                 title={t("prompt.stop")}
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/components/settings/McpSettings.tsx
+++ b/src/components/settings/McpSettings.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, CheckCircle2, Globe, Terminal } from "lucide-react";
 import type { McpStatus } from "@opencode-ai/sdk/v2/client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { HARNESS_LABELS, type HarnessId } from "@/agents";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,14 +9,22 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useConnectionState } from "@/hooks/use-agent-state";
 import { useHarness, useAvailableHarnessIds, useCurrentHarnessId } from "@/hooks/use-agent-backend";
+import { MCP_TOGGLE_DELAY_MS } from "@/lib/constants";
+import { useOpenGuiClient } from "@/protocol/provider";
 
 // ---------------------------------------------------------------------------
 // MCP/Tools tab content (inline)
 // ---------------------------------------------------------------------------
 
 export function McpTabContent() {
+  const { t } = useTranslation();
   const initialBackendId = useCurrentHarnessId();
   const availableBackendIds = useAvailableHarnessIds();
+  const openGuiClient = useOpenGuiClient();
+  const mcpHarnessIds = useMemo(
+    () => availableBackendIds.filter((id) => openGuiClient.harnesses.get(id)?.capabilities.mcp),
+    [availableBackendIds, openGuiClient],
+  );
   const [harnessId, setBackendId] = useState<HarnessId>(initialBackendId);
   const backend = useHarness(harnessId);
   const mcpApi = backend?.platform?.mcp;
@@ -30,8 +39,18 @@ export function McpTabContent() {
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (mcpHarnessIds.length === 0 || mcpHarnessIds.includes(harnessId)) return;
+    setBackendId(mcpHarnessIds[0]!);
+  }, [harnessId, mcpHarnessIds]);
+
   const refresh = useCallback(async () => {
-    if (!mcpApi || !configApi) return;
+    if (!mcpApi || !configApi) {
+      setMcpStatus({});
+      setMcpTypes({});
+      setLoading(false);
+      return;
+    }
     const target = { directory: scopedDirectory, workspaceId: activeWorkspaceId };
     const [statusData, configData] = await Promise.all([
       mcpApi.status(target),
@@ -51,6 +70,7 @@ export function McpTabContent() {
   }, [mcpApi, configApi, scopedDirectory, activeWorkspaceId]);
 
   useEffect(() => {
+    setLoading(true);
     void refresh();
   }, [refresh]);
 
@@ -66,7 +86,7 @@ export function McpTabContent() {
       } else {
         await mcpApi.connect({ directory: scopedDirectory, workspaceId: activeWorkspaceId }, name);
       }
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, MCP_TOGGLE_DELAY_MS));
       await refresh();
     } finally {
       setToggling(null);
@@ -76,24 +96,24 @@ export function McpTabContent() {
   const STATUS_CONFIG = {
     connected: {
       variant: "default" as const,
-      label: "Connected",
+      label: t("mcp.connected"),
       icon: CheckCircle2,
       className: "bg-emerald-600 hover:bg-emerald-600",
     },
-    disabled: { variant: "secondary" as const, label: "Disabled" },
+    disabled: { variant: "secondary" as const, label: t("mcp.disabled") },
     failed: {
       variant: "destructive" as const,
-      label: "Failed",
+      label: t("mcp.failed"),
       icon: AlertCircle,
     },
     needs_auth: {
       variant: "outline" as const,
-      label: "Needs auth",
+      label: t("mcp.needsAuth"),
       className: "text-amber-500 border-amber-500",
     },
     needs_client_registration: {
       variant: "outline" as const,
-      label: "Needs registration",
+      label: t("mcp.needsRegistration"),
       className: "text-amber-500 border-amber-500",
     },
   } as const;
@@ -110,9 +130,9 @@ export function McpTabContent() {
 
   return (
     <div className="space-y-2">
-      {availableBackendIds.length > 1 && (
+      {mcpHarnessIds.length > 1 && (
         <div className="mb-3 flex flex-wrap gap-1">
-          {availableBackendIds.map((id) => (
+          {mcpHarnessIds.map((id) => (
             <Button
               key={id}
               type="button"
@@ -126,9 +146,13 @@ export function McpTabContent() {
           ))}
         </div>
       )}
-      {entries.length === 0 ? (
+      {!mcpApi || !configApi ? (
         <div className="text-center py-6 text-sm text-muted-foreground">
-          No MCP servers configured.
+          {t("mcp.noManagement")}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="text-center py-6 text-sm text-muted-foreground">
+          {t("mcp.noneConfigured")}
         </div>
       ) : (
         entries.map(([name, status]) => {
@@ -137,7 +161,7 @@ export function McpTabContent() {
           const type = mcpTypes[name];
           const config = STATUS_CONFIG[status.status as keyof typeof STATUS_CONFIG] ?? {
             variant: "secondary" as const,
-            label: "Unknown",
+            label: t("mcp.unknown"),
           };
           const BadgeIcon = "icon" in config ? config.icon : undefined;
 

--- a/src/hooks/use-agent-impl-core.tsx
+++ b/src/hooks/use-agent-impl-core.tsx
@@ -2013,25 +2013,46 @@ function InternalAgentProvider({
 
   const respondPermission = useCallback(
     async (response: "once" | "always" | "reject") => {
-      if (!state.activeSessionId) return;
-      const pending = state.pendingPermissions[state.activeSessionId];
+      const sessionId = state.activeSessionId;
+      if (!sessionId) return;
+      const pending = state.pendingPermissions[sessionId];
       if (!pending) return;
-      const session = state.sessions.find((item) => item.id === state.activeSessionId);
-      await openGuiClient.sessions.respondPermission({
-        sessionId: state.activeSessionId,
-        permissionId: pending.id,
-        response,
-        harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
-        target:
-          getSessionProjectTarget(session, session ? state.sessionMeta[session.id] : undefined) ??
-          undefined,
-      });
-      dispatch({
-        type: "SET_PERMISSION",
-        payload: { sessionID: state.activeSessionId, clear: true },
-      });
+      const session = state.sessions.find((item) => item.id === sessionId);
+      const clearPermission = () =>
+        dispatch({
+          type: "SET_PERMISSION",
+          payload: { sessionID: sessionId, clear: true },
+        });
+
+      try {
+        await openGuiClient.sessions.respondPermission({
+          sessionId,
+          permissionId: pending.id,
+          response,
+          harnessId: resolveSessionHarnessRoute(session).harnessId ?? undefined,
+          target:
+            getSessionProjectTarget(session, session ? state.sessionMeta[session.id] : undefined) ??
+            undefined,
+        });
+        clearPermission();
+      } catch (error) {
+        const message = getErrorMessage(error);
+        if (/permission request not found|permission not found|not found/i.test(message)) {
+          clearPermission();
+        }
+        dispatch({
+          type: "SET_ERROR",
+          payload: message || "Failed to respond to permission request",
+        });
+      }
     },
-    [openGuiClient, state.pendingPermissions, state.activeSessionId, state.sessions],
+    [
+      openGuiClient,
+      state.activeSessionId,
+      state.pendingPermissions,
+      state.sessionMeta,
+      state.sessions,
+    ],
   );
 
   const replyQuestion = useCallback(

--- a/src/protocol/http-client.ts
+++ b/src/protocol/http-client.ts
@@ -1079,6 +1079,7 @@ export function createHttpOpenGuiClient(options: HttpOpenGuiClientOptions = {}):
               harnessId,
               workspaceId: project?.workspaceId ?? target?.workspaceId,
               projectId: project?.id,
+              directory: target?.directory,
             }),
           },
         );

--- a/src/server-harness-service.test.ts
+++ b/src/server-harness-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import { HarnessService } from "../server/services/harness-service.ts";
+import type { SessionRecord } from "../server/services/session-types.ts";
+
+describe("HarnessService.respondPermission", () => {
+  test("passes directory and workspace scope to session-routed harness RPC", async () => {
+    const calls: Array<{ channel: string; args?: unknown[] }> = [];
+    const invoke = async <T>(channel: string, args?: unknown[]): Promise<T> => {
+      calls.push({ channel, args });
+      return { success: true } as T;
+    };
+    const service = new HarnessService(invoke, new Map(), ["opencode"]);
+
+    const session: SessionRecord = {
+      id: "session-1",
+      rawId: "raw-session-1",
+      projectId: "project-1",
+      harnessId: "opencode",
+      title: "Work",
+      status: "running",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    await service.respondPermission({
+      session,
+      permissionId: "per-1",
+      response: "once",
+      scope: { directory: "/repo", workspaceId: "workspace-1" },
+    });
+
+    expect(calls).toEqual([
+      {
+        channel: "opencode:permission",
+        args: ["raw-session-1", "per-1", "once", "/repo", "workspace-1"],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- route OpenCode permission replies with explicit project/workspace scope
- recover permission responses for frontend-only OpenCode session IDs
- handle stale permission replies in the UI instead of leaving stuck panels
- map OpenCode permission.v2 events and add regression coverage

## Validation
- vp test run src/server-harness-service.test.ts src/agents/protocol/opencode-map.test.ts
- vp check (passes with existing pi-bridge await-thenable warnings)
- vp build
- verified in Linux and Windows QEMU VM