### PR TITLE
fix: load older chat history when scrolling to top

### DIFF
--- a/src/components/message-list/VirtualMessageScroller.test.ts
+++ b/src/components/message-list/VirtualMessageScroller.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
-import { distanceFromBottom, isAtTop, isNearBottom } from "./VirtualMessageScroller";
+import {
+  distanceFromBottom,
+  isAtTop,
+  isNearBottom,
+  shouldLoadOlderMessages,
+} from "./VirtualMessageScroller";
 
 function scrollElement(input: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
   return input as HTMLElement;
@@ -28,5 +33,45 @@ describe("VirtualMessageScroller scroll position helpers", () => {
     expect(isAtTop(element)).toBe(true);
     expect(distanceFromBottom(element)).toBe(0);
     expect(isNearBottom(element)).toBe(true);
+  });
+});
+
+describe("shouldLoadOlderMessages", () => {
+  test("requests older history near the top of a paged transcript", () => {
+    expect(
+      shouldLoadOlderMessages({
+        firstIndex: 0,
+        hasOlder: true,
+        isLoadingOlder: false,
+        loadInFlight: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not request older history while away from top or already loading", () => {
+    expect(
+      shouldLoadOlderMessages({
+        firstIndex: 12,
+        hasOlder: true,
+        isLoadingOlder: false,
+        loadInFlight: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadOlderMessages({
+        firstIndex: 0,
+        hasOlder: true,
+        isLoadingOlder: true,
+        loadInFlight: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadOlderMessages({
+        firstIndex: 0,
+        hasOlder: true,
+        isLoadingOlder: false,
+        loadInFlight: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/components/message-list/VirtualMessageScroller.test.ts
+++ b/src/components/message-list/VirtualMessageScroller.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "@voidzero-dev/vite-plus-test";
+import { distanceFromBottom, isAtTop, isNearBottom } from "./VirtualMessageScroller";
+
+function scrollElement(input: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
+  return input as HTMLElement;
+}
+
+describe("VirtualMessageScroller scroll position helpers", () => {
+  test("does not treat top of an overflowing chat as pinned to bottom", () => {
+    const element = scrollElement({ scrollHeight: 5000, scrollTop: 0, clientHeight: 800 });
+
+    expect(isAtTop(element)).toBe(true);
+    expect(distanceFromBottom(element)).toBe(4200);
+    expect(isNearBottom(element)).toBe(false);
+  });
+
+  test("treats real bottom as pinned to bottom", () => {
+    const element = scrollElement({ scrollHeight: 5000, scrollTop: 4200, clientHeight: 800 });
+
+    expect(isAtTop(element)).toBe(false);
+    expect(distanceFromBottom(element)).toBe(0);
+    expect(isNearBottom(element)).toBe(true);
+  });
+
+  test("keeps short non-scrollable chats pinned to bottom", () => {
+    const element = scrollElement({ scrollHeight: 700, scrollTop: 0, clientHeight: 800 });
+
+    expect(isAtTop(element)).toBe(true);
+    expect(distanceFromBottom(element)).toBe(0);
+    expect(isNearBottom(element)).toBe(true);
+  });
+});

--- a/src/components/message-list/VirtualMessageScroller.tsx
+++ b/src/components/message-list/VirtualMessageScroller.tsx
@@ -57,6 +57,26 @@ export function isNearBottom(
   return distanceFromBottom(element) <= NEAR_BOTTOM_PX;
 }
 
+export function shouldLoadOlderMessages({
+  firstIndex,
+  hasOlder,
+  isLoadingOlder,
+  loadInFlight,
+}: {
+  firstIndex: number | undefined;
+  hasOlder: boolean;
+  isLoadingOlder: boolean;
+  loadInFlight: boolean;
+}) {
+  return (
+    firstIndex != null &&
+    firstIndex <= LOAD_OLDER_THRESHOLD_INDEX &&
+    hasOlder &&
+    !isLoadingOlder &&
+    !loadInFlight
+  );
+}
+
 export function VirtualMessageScroller({
   scrollKey,
   scrollSnapshotsRef,
@@ -151,6 +171,39 @@ export function VirtualMessageScroller({
       offsetFromViewportTop: first.start - scrollEl.scrollTop,
     };
   }, [virtualizer]);
+
+  const releaseOlderLoadLock = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        loadInFlightRef.current = false;
+      });
+    });
+  }, []);
+
+  const maybeLoadOlder = useCallback(() => {
+    const firstIndex = virtualizer.getVirtualItems()[0]?.index;
+    if (
+      !shouldLoadOlderMessages({
+        firstIndex,
+        hasOlder,
+        isLoadingOlder,
+        loadInFlight: loadInFlightRef.current,
+      })
+    ) {
+      return;
+    }
+
+    loadInFlightRef.current = true;
+    capturePaginationAnchor();
+    void loadOlder().finally(releaseOlderLoadLock);
+  }, [
+    capturePaginationAnchor,
+    hasOlder,
+    isLoadingOlder,
+    loadOlder,
+    releaseOlderLoadLock,
+    virtualizer,
+  ]);
 
   const setProgrammaticScrollTop = useCallback((scrollTop: number) => {
     const scrollEl = scrollRef.current;
@@ -256,13 +309,16 @@ export function VirtualMessageScroller({
     if (!el || programmaticScrollRef.current) return;
     pinnedToBottomRef.current = isNearBottom(el);
     scheduleScrollSnapshot();
-  }, [scheduleScrollSnapshot]);
+    requestAnimationFrame(maybeLoadOlder);
+  }, [maybeLoadOlder, scheduleScrollSnapshot]);
 
   const handleWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
-      if (event.deltaY < 0) detachFromBottom(true);
+      if (event.deltaY >= 0) return;
+      detachFromBottom(true);
+      requestAnimationFrame(maybeLoadOlder);
     },
-    [detachFromBottom],
+    [detachFromBottom, maybeLoadOlder],
   );
 
   useLayoutEffect(() => {
@@ -310,33 +366,22 @@ export function VirtualMessageScroller({
     captureScrollSnapshot();
   }, [captureScrollSnapshot, keys, scrollKey, scrollToLatest]);
 
-  useEffect(() => {
-    const firstIndex = virtualizer.getVirtualItems()[0]?.index;
-    if (
-      firstIndex == null ||
-      firstIndex > LOAD_OLDER_THRESHOLD_INDEX ||
-      !hasOlder ||
-      isLoadingOlder ||
-      loadInFlightRef.current
-    ) {
-      return;
-    }
-
-    loadInFlightRef.current = true;
-    capturePaginationAnchor();
-    void loadOlder().finally(() => {
-      loadInFlightRef.current = false;
-    });
-  }, [capturePaginationAnchor, hasOlder, isLoadingOlder, loadOlder, virtualizer]);
-
   const virtualItems = virtualizer.getVirtualItems();
+  const firstVirtualIndex = virtualItems[0]?.index;
+
+  useEffect(() => {
+    maybeLoadOlder();
+  }, [firstVirtualIndex, maybeLoadOlder]);
 
   return (
     <div
       ref={scrollRef}
       onScroll={handleScroll}
       onWheel={handleWheel}
-      onTouchMove={() => detachFromBottom(true)}
+      onTouchMove={() => {
+        detachFromBottom(true);
+        requestAnimationFrame(maybeLoadOlder);
+      }}
       className="relative flex-1 overflow-auto px-4 py-4"
     >
       <div className="max-w-[640px] mx-auto">

--- a/src/components/message-list/VirtualMessageScroller.tsx
+++ b/src/components/message-list/VirtualMessageScroller.tsx
@@ -23,6 +23,7 @@ export type ScrollSnapshot = {
   offsetFromViewportTop: number;
   scrollTop: number;
   distanceFromBottom: number;
+  atTop: boolean;
   pinnedToBottom: boolean;
   updatedAt: number;
 };
@@ -37,12 +38,23 @@ function estimateMessageSize(message: MessageEntry): number {
   return Math.min(720, Math.max(140, 120 + partCount * 36 + Math.ceil(textLength / 90) * 18));
 }
 
-function isNearBottom(element: HTMLElement) {
-  return element.scrollHeight - element.scrollTop - element.clientHeight <= NEAR_BOTTOM_PX;
+export function distanceFromBottom(
+  element: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+) {
+  return Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight);
 }
 
-function distanceFromBottom(element: HTMLElement) {
-  return Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight);
+export function isAtTop(element: Pick<HTMLElement, "scrollTop">) {
+  return element.scrollTop <= NEAR_BOTTOM_PX;
+}
+
+export function isNearBottom(
+  element: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+) {
+  const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+  if (maxScrollTop <= NEAR_BOTTOM_PX) return true;
+  if (isAtTop(element)) return false;
+  return distanceFromBottom(element) <= NEAR_BOTTOM_PX;
 }
 
 export function VirtualMessageScroller({
@@ -101,6 +113,7 @@ export function VirtualMessageScroller({
       const scrollEl = scrollRef.current;
       if (!scrollEl) return;
       const first = virtualizer.getVirtualItems()[0];
+      const atTop = isAtTop(scrollEl);
       const pinnedToBottom = isNearBottom(scrollEl);
       pinnedToBottomRef.current = pinnedToBottom;
       scrollSnapshotsRef.current.set(sessionId, {
@@ -108,6 +121,7 @@ export function VirtualMessageScroller({
         offsetFromViewportTop: first ? first.start - scrollEl.scrollTop : 0,
         scrollTop: scrollEl.scrollTop,
         distanceFromBottom: distanceFromBottom(scrollEl),
+        atTop,
         pinnedToBottom,
         updatedAt: Date.now(),
       });
@@ -187,6 +201,12 @@ export function VirtualMessageScroller({
     (snapshot: ScrollSnapshot) => {
       const scrollEl = scrollRef.current;
       if (!scrollEl) return false;
+
+      if (snapshot.atTop) {
+        virtualizer.scrollToIndex(0, { align: "start" });
+        setProgrammaticScrollTop(0);
+        return true;
+      }
 
       if (snapshot.pinnedToBottom) {
         scrollToLatest();

--- a/src/hooks/agent-message-state.test.ts
+++ b/src/hooks/agent-message-state.test.ts
@@ -65,6 +65,40 @@ describe("mergeMessageSnapshot", () => {
     expect(merged.map((entry) => entry.info.id)).toEqual(["old", "new-live"]);
   });
 
+  test("preserves older loaded messages when replacing with a paged snapshot", () => {
+    const existing = [
+      message("original-user", 1, [textPart("original-part", "original-user", "first prompt")]),
+      message("older-assistant", 2, [textPart("older-part", "older-assistant", "early reply")]),
+      message("recent-assistant", 10, [textPart("recent-part", "recent-assistant", "recent")]),
+    ];
+    const incoming = [
+      message("recent-assistant", 10, [textPart("recent-part", "recent-assistant", "updated")]),
+    ];
+
+    const merged = mergeMessageSnapshot(incoming, existing, {
+      preserveExistingBeforeIncoming: true,
+    });
+
+    expect(merged.map((entry) => entry.info.id)).toEqual([
+      "original-user",
+      "older-assistant",
+      "recent-assistant",
+    ]);
+    expect((merged[2]?.parts[0] as Record<string, unknown>)?.text).toBe("updated");
+  });
+
+  test("full snapshots can still replace older messages", () => {
+    const existing = [
+      message("stale-old", 1, [textPart("stale-part", "stale-old", "stale")]),
+      message("fresh", 10, [textPart("fresh-part", "fresh", "fresh")]),
+    ];
+    const incoming = [message("fresh", 10, [textPart("fresh-part", "fresh", "fresh")])];
+
+    const merged = mergeMessageSnapshot(incoming, existing);
+
+    expect(merged.map((entry) => entry.info.id)).toEqual(["fresh"]);
+  });
+
   test("canonical user message replaces matching optimistic user message", () => {
     const optimistic = {
       info: {

--- a/src/hooks/agent-message-state.ts
+++ b/src/hooks/agent-message-state.ts
@@ -364,6 +364,7 @@ export function finalizeRunningToolPartsForSession(
 export function mergeMessageSnapshot(
   incomingMessages: MessageEntry[],
   existingMessages: MessageEntry[],
+  options: { preserveExistingBeforeIncoming?: boolean } = {},
 ): MessageEntry[] {
   const normalizedMessages = normalizeMessageEntries(incomingMessages, existingMessages);
   if (normalizedMessages.length === 0) return limitMessageWindow(existingMessages);
@@ -403,15 +404,23 @@ export function mergeMessageSnapshot(
   });
 
   const incomingIds = new Set(incomingMessages.map((message) => message.info.id));
+  const serverFirst = normalizedMessages[0];
   const serverLast = normalizedMessages[normalizedMessages.length - 1];
+  const serverFirstCreated = serverFirst?.info.time.created ?? 0;
   const serverLastCreated = serverLast?.info.time.created ?? 0;
+  const preservedOlder: MessageEntry[] = [];
+  const preservedNewer: MessageEntry[] = [];
   for (const entry of existingMessages) {
     if (incomingIds.has(entry.info.id) || optimisticIdsToDrop.has(entry.info.id)) continue;
     const entryCreated = entry.info.time.created ?? 0;
-    if (entryCreated > serverLastCreated) mergedMessages.push(entry);
+    if (options.preserveExistingBeforeIncoming && entryCreated < serverFirstCreated) {
+      preservedOlder.push(entry);
+    } else if (entryCreated > serverLastCreated) {
+      preservedNewer.push(entry);
+    }
   }
 
-  return limitMessageWindow(mergedMessages);
+  return limitMessageWindow([...preservedOlder, ...mergedMessages, ...preservedNewer]);
 }
 
 export function limitMessageWindow(messages: MessageEntry[]): MessageEntry[] {

--- a/src/hooks/agent-reducer.ts
+++ b/src/hooks/agent-reducer.ts
@@ -882,7 +882,9 @@ export function reducer(state: InternalAgentState, action: Action): InternalAgen
 
       let replayedState: InternalAgentState = {
         ...state,
-        messages: mergeMessageSnapshot(action.payload.messages, state.messages),
+        messages: mergeMessageSnapshot(action.payload.messages, state.messages, {
+          preserveExistingBeforeIncoming: action.payload.hasMore || state.messageHistoryHasMore,
+        }),
         messageHistoryHasMore: action.payload.hasMore,
         messageHistoryCursor: action.payload.nextCursor ?? null,
         isLoadingMessages: false,


### PR DESCRIPTION
## Summary
- Trigger older-message pagination whenever the virtual scroller reaches the top window.
- Keep already loaded older messages when paged refresh snapshots arrive.
- Add regression tests for top pagination and paged snapshot merging.

## Validation
- vp test src/components/message-list/VirtualMessageScroller.test.ts src/hooks/agent-message-state.test.ts src/hooks/agent-reducer.test.ts
- vp check
- vp build