### PR TITLE
fix: translate remaining UI labels

### DIFF
--- a/src/components/AgentSelector.tsx
+++ b/src/components/AgentSelector.tsx
@@ -7,6 +7,7 @@
 
 import { Bot } from "lucide-react";
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Select,
   SelectContent,
@@ -19,6 +20,7 @@ import { useActions, useModelState } from "@/hooks/use-agent-state";
 import { DEFAULT_AGENT_NAME, getPrimaryAgents } from "@/lib/utils";
 
 export function AgentSelector() {
+  const { t } = useTranslation();
   const { setAgent } = useActions();
   const { agents, selectedAgent } = useModelState();
   const capabilities = useBackendCapabilities();
@@ -38,7 +40,7 @@ export function AgentSelector() {
     <Select value={currentValue} onValueChange={handleChange}>
       <SelectTrigger className="!h-7 w-auto max-w-[180px] gap-1.5 border-none bg-transparent px-2 py-0 text-xs text-muted-foreground shadow-none hover:text-foreground focus:ring-0 [&>svg]:size-3">
         <Bot className="size-3.5 shrink-0" />
-        <SelectValue placeholder="Agent" />
+        <SelectValue placeholder={t("agentSelector.placeholder")} />
       </SelectTrigger>
       <SelectContent
         position="popper"

--- a/src/components/ImageMentionPreview.tsx
+++ b/src/components/ImageMentionPreview.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { resolveAttachmentImageSrc } from "@/lib/attachment-src";
 import { cn } from "@/lib/utils";
 
@@ -20,6 +21,8 @@ function ImageLightbox({
   baseDirectory?: string | null;
   onClose: () => void;
 }) {
+  const { t } = useTranslation();
+
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
@@ -43,7 +46,7 @@ function ImageLightbox({
           type="button"
           className="absolute right-2 top-2 rounded-full bg-background/90 p-1.5 text-muted-foreground shadow-sm hover:text-foreground"
           onClick={onClose}
-          aria-label="Close image preview"
+          aria-label={t("attachments.closeImagePreview")}
         >
           <X className="size-4" />
         </button>

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -24,6 +24,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -77,6 +78,7 @@ function QueueItemRow({
   const [editValue, setEditValue] = React.useState(item.text);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const { t } = useTranslation();
   const rowRef = React.useRef<HTMLDivElement>(null);
 
   const isFirst = index === 0;
@@ -155,7 +157,7 @@ function QueueItemRow({
       <div
         {...dragHandleProps}
         className="size-3.5 cursor-grab text-muted-foreground/50 shrink-0 active:cursor-grabbing"
-        aria-label="Reorder queued prompt"
+        aria-label={t("queueList.reorderQueuedPrompt")}
       >
         <GripVertical className="size-3.5" />
       </div>
@@ -193,7 +195,7 @@ function QueueItemRow({
                   : "bg-amber-500/15 text-amber-600 dark:text-amber-400",
               )}
             >
-              {item.mode === "interrupt" ? "interrupt" : "steer"}
+              {item.mode === "interrupt" ? t("queueList.interrupt") : t("queueList.steer")}
             </span>
           )}
           {item.variant && (
@@ -214,7 +216,7 @@ function QueueItemRow({
               onSendNow?.(item.id);
             }}
             className="text-muted-foreground hover:text-foreground"
-            title="Send now"
+            title={t("queueList.sendNow")}
           >
             <Send className="size-3" />
           </Button>
@@ -264,7 +266,7 @@ function QueueItemRow({
                   }}
                 >
                   <Pencil className="size-3" />
-                  Edit
+                  {t("queueList.edit")}
                 </button>
                 {!isFirst && (
                   <button
@@ -277,7 +279,7 @@ function QueueItemRow({
                     }}
                   >
                     <ArrowUpToLine className="size-3" />
-                    Move to top
+                    {t("queueList.moveToTop")}
                   </button>
                 )}
                 {!isLast && (
@@ -291,7 +293,7 @@ function QueueItemRow({
                     }}
                   >
                     <ArrowDownToLine className="size-3" />
-                    Move to bottom
+                    {t("queueList.moveToBottom")}
                   </button>
                 )}
               </div>

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { DialogShell } from "@/components/ui/DialogShell";
 import { Button } from "@/components/ui/button";
 import type { UpdateCheckResult } from "@/hooks/use-update-check";
@@ -8,30 +9,28 @@ interface UpdateDialogProps {
   update: UpdateCheckResult;
 }
 
-function buildDescription(update: UpdateCheckResult): string {
-  const { latestVersion } = update;
-  if (latestVersion) {
-    return `A new version of OpenGUI (${latestVersion}) is available. You are currently running v${packageJson.version}.`;
-  }
-  return `Current version: v${packageJson.version}.`;
-}
-
 export function UpdateDialog({ update }: UpdateDialogProps) {
-  const { updateAvailable, releaseUrl, dismiss } = update;
+  const { t } = useTranslation();
+  const { updateAvailable, releaseUrl, dismiss, latestVersion } = update;
 
   const open = updateAvailable;
-  const description = buildDescription(update);
+  const description = latestVersion
+    ? t("updateDialog.description", {
+        latestVersion,
+        currentVersion: packageJson.version,
+      })
+    : t("updateDialog.currentVersion", { currentVersion: packageJson.version });
 
   return (
     <DialogShell
       open={open}
       onOpenChange={(nextOpen) => !nextOpen && dismiss()}
-      title="Update Available"
+      title={t("updateDialog.title")}
       description={description}
       footer={
         <>
           <Button variant="outline" onClick={dismiss}>
-            Dismiss
+            {t("updateDialog.dismiss")}
           </Button>
           {releaseUrl && (
             <Button
@@ -40,7 +39,7 @@ export function UpdateDialog({ update }: UpdateDialogProps) {
                 dismiss();
               }}
             >
-              Open
+              {t("updateDialog.open")}
             </Button>
           )}
         </>

--- a/src/components/WorktreeCleanupDialog.tsx
+++ b/src/components/WorktreeCleanupDialog.tsx
@@ -1,5 +1,6 @@
 import { GitBranch, Trash2 } from "lucide-react";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { BaseDialog } from "@/components/ui/base-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -8,6 +9,7 @@ import { getProjectName } from "@/lib/utils";
 import { useOpenGuiClient } from "@/protocol/provider";
 
 export function WorktreeCleanupDialog() {
+  const { t } = useTranslation();
   const client = useOpenGuiClient();
   const { pendingWorktreeCleanup, worktreeParents } = useConnectionState();
   const { unregisterWorktree, removeProject, clearWorktreeCleanup } = useActions();
@@ -59,29 +61,30 @@ export function WorktreeCleanupDialog() {
       title={
         <span className="flex items-center gap-2">
           <GitBranch className="size-4" />
-          No sessions remaining
+          {t("worktreeCleanup.title")}
         </span>
       }
       description={
         <>
-          The worktree <strong>{getProjectName(worktreeDir)}</strong>
+          {t("worktreeCleanup.descriptionPrefix")} <strong>{getProjectName(worktreeDir)}</strong>
           {meta?.branch && meta.branch !== "unknown" && (
             <>
               {" "}
-              (branch <code className="rounded bg-muted px-1 text-xs">{meta.branch}</code>)
+              ({t("worktreeCleanup.branch")}{" "}
+              <code className="rounded bg-muted px-1 text-xs">{meta.branch}</code>)
             </>
           )}{" "}
-          has no active sessions. Would you like to remove it?
+          {t("worktreeCleanup.descriptionSuffix")}
         </>
       }
       footer={
         <>
           <Button variant="ghost" onClick={handleKeep} disabled={removing}>
-            Keep
+            {t("worktreeCleanup.keep")}
           </Button>
           <Button variant="destructive" onClick={handleRemove} disabled={removing}>
             <Trash2 className="mr-1.5 size-3.5" />
-            {removing ? "Removing..." : "Remove"}
+            {removing ? t("worktreeCleanup.removing") : t("worktreeCleanup.remove")}
           </Button>
         </>
       }
@@ -93,7 +96,7 @@ export function WorktreeCleanupDialog() {
           onCheckedChange={(checked) => setDeleteFromDisk(checked === true)}
         />
         <label htmlFor="delete-from-disk" className="cursor-pointer text-sm">
-          Also delete worktree files from disk
+          {t("worktreeCleanup.deleteFromDisk")}
         </label>
       </div>
     </BaseDialog>

--- a/src/components/message-list/FilePartView.tsx
+++ b/src/components/message-list/FilePartView.tsx
@@ -1,8 +1,10 @@
 import type { FilePart } from "@opencode-ai/sdk/v2/client";
+import { useTranslation } from "react-i18next";
 import { useConnectionState } from "@/hooks/use-agent-state";
 import { resolveAttachmentImageSrc } from "@/lib/attachment-src";
 
 export function FilePartView({ part }: { part: FilePart }) {
+  const { t } = useTranslation();
   const { workspaceServerUrl } = useConnectionState();
   const isImage = (part.mime ?? "").toLowerCase().startsWith("image/");
   const src = resolveAttachmentImageSrc(part.url, workspaceServerUrl);
@@ -12,7 +14,7 @@ export function FilePartView({ part }: { part: FilePart }) {
       <div>
         <img
           src={src}
-          alt={part.filename ?? "Image"}
+          alt={part.filename ?? t("attachments.image")}
           className="max-h-64 max-w-full rounded-lg object-contain"
         />
         {part.filename && (
@@ -23,6 +25,8 @@ export function FilePartView({ part }: { part: FilePart }) {
   }
 
   return (
-    <div className="text-sm text-muted-foreground italic">{part.filename ?? "File attachment"}</div>
+    <div className="text-sm text-muted-foreground italic">
+      {part.filename ?? t("attachments.fileAttachment")}
+    </div>
   );
 }

--- a/src/components/message-list/ReasoningPartView.tsx
+++ b/src/components/message-list/ReasoningPartView.tsx
@@ -1,6 +1,7 @@
 import type { ReasoningPart } from "@opencode-ai/sdk/v2/client";
 import { ChevronRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { useSessionState } from "@/hooks/use-agent-state";
 import { cn } from "@/lib/utils";
@@ -18,6 +19,7 @@ export function ReasoningPartView({
   isLastReasoning?: boolean;
 }) {
   const isThinking = !part.time.end;
+  const { t } = useTranslation();
   const { isBusy } = useSessionState();
   const [expanded, setExpanded] = useState(isThinking);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -65,7 +67,9 @@ export function ReasoningPartView({
               className={cn("size-3 transition-transform duration-150", expanded && "rotate-90")}
             />
           </span>
-          <span className="font-medium">{isThinking ? "Thinking..." : "Thinking"}</span>
+          <span className="font-medium">
+            {isThinking ? t("reasoning.thinkingRunning") : t("reasoning.thinking")}
+          </span>
           {durationLabel && <span className="opacity-60">{durationLabel}</span>}
         </summary>
       </details>

--- a/src/components/message-list/tools/ApplyPatchFilesView.tsx
+++ b/src/components/message-list/tools/ApplyPatchFilesView.tsx
@@ -22,7 +22,7 @@ export function ApplyPatchFilesView({ files }: { files: ApplyPatchFileDiff[] }) 
     <div className="mt-1 ml-5 space-y-1.5">
       {files.map((file) => {
         const hasDiff = file.lines.length > 0;
-        const actionLabel = getApplyPatchActionLabel(file);
+        const actionLabel = getApplyPatchActionLabel(file, t);
         const pathLabel =
           file.type === "move" && file.previousPath && file.previousPath !== file.path
             ? `${file.previousPath} -> ${file.path}`

--- a/src/components/message-list/tools/ToolPartView.tsx
+++ b/src/components/message-list/tools/ToolPartView.tsx
@@ -18,6 +18,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { TerminalOutput } from "@/components/message-list/TerminalOutput";
 import { Spinner } from "@/components/ui/spinner";
@@ -94,6 +95,7 @@ function ToolHeader({
   expanded: boolean;
   setExpanded: (expanded: boolean) => void;
 }) {
+  const { t } = useTranslation();
   const { tool, expandable } = presentation;
   const Icon = toolIcon(tool.kind);
   const icon = expandable ? (
@@ -121,7 +123,12 @@ function ToolHeader({
       )}
       {presentation.grepMatchCount != null && (
         <span className="text-[11px] text-blue-400 ml-auto whitespace-nowrap">
-          {presentation.grepMatchCount} {presentation.grepMatchCount === 1 ? "match" : "matches"}
+          {t(
+            presentation.grepMatchCount === 1
+              ? "toolLabels.matchCountOne"
+              : "toolLabels.matchCountOther",
+            { count: presentation.grepMatchCount },
+          )}
         </span>
       )}
       {presentation.diffSummary && (
@@ -159,6 +166,7 @@ function ToolHeader({
 }
 
 function ToolImages({ presentation }: { presentation: ToolPresentation }) {
+  const { t } = useTranslation();
   if (presentation.sideContent.images.length === 0) return null;
 
   return (
@@ -175,7 +183,7 @@ function ToolImages({ presentation }: { presentation: ToolPresentation }) {
         >
           <img
             src={image.src}
-            alt={image.filename ?? `Image attachment ${idx + 1}`}
+            alt={image.filename ?? t("attachments.imageAttachment", { count: idx + 1 })}
             loading="lazy"
             className="w-full max-h-52 object-contain bg-black/20"
           />
@@ -279,7 +287,8 @@ export function ToolPartView({
   onToggleToolPart?: (partId: string, expanded: boolean) => void;
 }) {
   const { workspaceServerUrl } = useConnectionState();
-  const presentation = getToolPresentation(part, workspaceServerUrl);
+  const { t } = useTranslation();
+  const presentation = getToolPresentation(part, workspaceServerUrl, t);
   const expanded = expandedToolParts?.has(part.id) ?? false;
   const setExpanded = (nextExpanded: boolean) => onToggleToolPart?.(part.id, nextExpanded);
   const autoExpandedRef = useRef(false);

--- a/src/components/message-list/tools/applyPatch.ts
+++ b/src/components/message-list/tools/applyPatch.ts
@@ -1,4 +1,5 @@
 import type { ToolPart } from "@opencode-ai/sdk/v2/client";
+import type { TFunction } from "i18next";
 import { parseUnifiedDiff, type DiffLine, type DiffResult } from "@/lib/diff";
 import { getToolInput, isRecord, stringField, toFiniteNumber } from "./toolTypes";
 
@@ -91,14 +92,17 @@ export function extractEditFiles(state: ToolPart["state"]): ApplyPatchFileDiff[]
   ];
 }
 
-export function getApplyPatchActionLabel(file: ApplyPatchFileDiff): string {
-  if (file.type === "add") return "Created";
-  if (file.type === "delete") return "Deleted";
-  if (file.type === "move") return "Moved";
-  return "Patched";
+export function getApplyPatchActionLabel(file: ApplyPatchFileDiff, t: TFunction): string {
+  if (file.type === "add") return t("toolLabels.patch.created");
+  if (file.type === "delete") return t("toolLabels.patch.deleted");
+  if (file.type === "move") return t("toolLabels.patch.moved");
+  return t("toolLabels.patch.patched");
 }
 
-export function getApplyPatchContextLabel(files: ApplyPatchFileDiff[]): string | null {
+export function getApplyPatchContextLabel(
+  files: ApplyPatchFileDiff[],
+  t: TFunction,
+): string | null {
   if (files.length === 0) return null;
   if (files.length === 1) {
     const file = files[0];
@@ -107,7 +111,7 @@ export function getApplyPatchContextLabel(files: ApplyPatchFileDiff[]): string |
       ? `${file.previousPath} -> ${file.path}`
       : file.path;
   }
-  return `${files.length} files`;
+  return t("toolLabels.fileCountOther", { count: files.length });
 }
 
 export function summarizeApplyPatchFiles(files: ApplyPatchFileDiff[]) {

--- a/src/components/message-list/tools/toolPresentation.ts
+++ b/src/components/message-list/tools/toolPresentation.ts
@@ -1,4 +1,5 @@
 import type { ToolPart } from "@opencode-ai/sdk/v2/client";
+import type { TFunction } from "i18next";
 import type { TodoItem } from "@/lib/todos";
 import { extractTodos } from "@/lib/todos";
 import type { ApplyPatchFileDiff } from "./applyPatch";
@@ -66,43 +67,51 @@ function getErrorText(state: ToolPart["state"]): string | null {
   return "error" in state && typeof state.error === "string" ? state.error : null;
 }
 
-function getToolTitle(part: ToolPart, kind: ToolKind, isRunning: boolean): string {
+function getToolTitle(part: ToolPart, kind: ToolKind, isRunning: boolean, t: TFunction): string {
   const input = getToolInput(part.state);
   const title =
     "title" in part.state && typeof part.state.title === "string" ? part.state.title : null;
 
   switch (kind) {
     case "bash":
-      return isRunning ? "Running" : "Ran";
+      return isRunning ? t("toolLabels.bash.running") : t("toolLabels.bash.done");
     case "read":
-      return isRunning ? "Reading" : "Read";
+      return isRunning ? t("toolLabels.read.running") : t("toolLabels.read.done");
     case "edit":
       return isRunning
-        ? "Editing"
+        ? t("toolLabels.edit.running")
         : part.tool.toLowerCase() === "apply_patch"
-          ? "Patched"
-          : "Edited";
+          ? t("toolLabels.patch.patched")
+          : t("toolLabels.edit.done");
     case "write":
-      return isRunning ? "Writing" : "Wrote";
+      return isRunning ? t("toolLabels.write.running") : t("toolLabels.write.done");
     case "grep":
-      return isRunning ? "Searching" : "Searched";
+      return isRunning ? t("toolLabels.grep.running") : t("toolLabels.grep.done");
     case "glob":
-      return isRunning ? "Globbing" : "Globbed";
+      return isRunning ? t("toolLabels.glob.running") : t("toolLabels.glob.done");
     case "task": {
       const subagent = input?.subagent_type ?? input?.subagentType;
       return typeof subagent === "string"
         ? subagent.charAt(0).toUpperCase() + subagent.slice(1)
         : isRunning
-          ? "Running"
-          : "Ran";
+          ? t("toolLabels.task.running")
+          : t("toolLabels.task.done");
     }
     case "todo": {
       const todoCount = Array.isArray(input?.todos) ? input.todos.length : 0;
-      return isRunning ? "Writing todos" : `Wrote ${todoCount} todos`;
+      return isRunning
+        ? t("toolLabels.todo.running")
+        : t(todoCount === 1 ? "toolLabels.todo.doneOne" : "toolLabels.todo.doneOther", {
+            count: todoCount,
+          });
     }
     case "question": {
       const qCount = Array.isArray(input?.questions) ? input.questions.length : 0;
-      return isRunning ? "Asking" : `Asked ${qCount} ${qCount === 1 ? "question" : "questions"}`;
+      return isRunning
+        ? t("toolLabels.question.running")
+        : t(qCount === 1 ? "toolLabels.question.doneOne" : "toolLabels.question.doneOther", {
+            count: qCount,
+          });
     }
     default:
       return title ?? part.tool;
@@ -111,7 +120,8 @@ function getToolTitle(part: ToolPart, kind: ToolKind, isRunning: boolean): strin
 
 export function getToolPresentation(
   part: ToolPart,
-  workspaceServerUrl?: string | null,
+  workspaceServerUrl: string | null | undefined,
+  t: TFunction,
 ): ToolPresentation {
   const state = part.state;
   const kind = normalizeToolKind(part.tool);
@@ -156,7 +166,7 @@ export function getToolPresentation(
       : null;
   const taskDescription =
     kind === "task" && taskInfo?.description ? `(${taskInfo.description})` : null;
-  const editFilesLabel = kind === "edit" ? getApplyPatchContextLabel(editFiles) : null;
+  const editFilesLabel = kind === "edit" ? getApplyPatchContextLabel(editFiles, t) : null;
   const stateTitle =
     state.status === "completed" &&
     state.title &&
@@ -196,7 +206,7 @@ export function getToolPresentation(
 
   return {
     tool: normalized,
-    title: getToolTitle(part, kind, isRunning),
+    title: getToolTitle(part, kind, isRunning, t),
     context,
     hasDynamicLabel: [
       "read",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
-
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -56,6 +57,8 @@ function DialogContent({
   showCloseButton?: boolean;
   onCloseAutoFocus?: (event: Event) => void;
 }) {
+  const { t } = useTranslation();
+
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -74,7 +77,7 @@ function DialogContent({
             render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("common.close")}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
@@ -96,6 +99,8 @@ function DialogFooter({
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean;
 }) {
+  const { t } = useTranslation();
+
   return (
     <div
       data-slot="dialog-footer"
@@ -107,7 +112,9 @@ function DialogFooter({
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          {t("common.close")}
+        </DialogPrimitive.Close>
       )}
     </div>
   );

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -2,10 +2,11 @@
 
 import * as React from "react";
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
-
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -48,6 +49,8 @@ function SheetContent({
   showCloseButton?: boolean;
   onOpenAutoFocus?: (event: Event) => void;
 }) {
+  const { t } = useTranslation();
+
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -67,7 +70,7 @@ function SheetContent({
             render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("common.close")}</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
@@ -161,6 +162,7 @@ function Sidebar({
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
 }) {
+  const { t } = useTranslation();
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
   if (collapsible === "none") {
@@ -195,8 +197,8 @@ function Sidebar({
           onOpenAutoFocus={(event) => event.preventDefault()}
         >
           <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+            <SheetTitle>{t("sidebar.title")}</SheetTitle>
+            <SheetDescription>{t("sidebar.mobileDescription")}</SheetDescription>
           </SheetHeader>
           <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>
@@ -253,6 +255,7 @@ function Sidebar({
 }
 
 function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
+  const { t } = useTranslation();
   const { toggleSidebar } = useSidebar();
 
   return (
@@ -269,22 +272,23 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("workspace.toggleSidebar")}</span>
     </Button>
   );
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { t } = useTranslation();
   const { toggleSidebar } = useSidebar();
 
   return (
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t("workspace.toggleSidebar")}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t("workspace.toggleSidebar")}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,11 +1,14 @@
 import { cn } from "@/lib/utils";
 import { Loader2Icon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  const { t } = useTranslation();
+
   return (
     <Loader2Icon
       role="status"
-      aria-label="Loading"
+      aria-label={t("common.loading")}
       className={cn("size-4 animate-spin", className)}
       {...props}
     />

--- a/src/hooks/use-file-mention.ts
+++ b/src/hooks/use-file-mention.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 
 export function findFileMentionTrigger(
   value: string,
@@ -34,6 +35,7 @@ export function useFileMention({
   ) => Promise<string[]>;
   getActiveTarget: () => { directory?: string; workspaceId?: string; baseUrl?: string } | null;
 }) {
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
   const [results, setResults] = React.useState<string[]>([]);
   const [activeIndex, setActiveIndex] = React.useState(0);
@@ -82,7 +84,7 @@ export function useFileMention({
       if (query.trim().length === 0) {
         setLoading(false);
         setResults([]);
-        setEmptyMessage("Type to search files");
+        setEmptyMessage(t("fileMention.typeToSearch"));
         return;
       }
 
@@ -93,16 +95,16 @@ export function useFileMention({
           const activeTarget = getActiveTarget();
           const found = await findFiles(activeTarget, query);
           setResults(found.slice(0, 20));
-          setEmptyMessage(found.length === 0 ? "No matching files" : null);
+          setEmptyMessage(found.length === 0 ? t("fileMention.noMatchingFiles") : null);
         } catch {
           setResults([]);
-          setEmptyMessage("File search failed");
+          setEmptyMessage(t("fileMention.searchFailed"));
         } finally {
           setLoading(false);
         }
       }, 150);
     },
-    [clearDebounce, dismiss, findFiles, getActiveTarget],
+    [clearDebounce, dismiss, findFiles, getActiveTarget, t],
   );
 
   const select = React.useCallback(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -136,6 +136,8 @@
     "projects": "Projekte",
     "searchPlaceholder": "Projekte und Sitzungen durchsuchen...",
     "showLess": "Weniger anzeigen",
+    "title": "Sidebar",
+    "mobileDescription": "Zeigt die mobile Sidebar an.",
     "untitled": "Ohne Titel"
   },
   "sessionMenu": {
@@ -191,6 +193,9 @@
   "variantSelector": {
     "off": "aus",
     "thinkingEffort": "Denkaufwand: {{level}} (Klick oder Strg+T zum Wechseln, Strg+Umschalt+T rückwärts)"
+  },
+  "agentSelector": {
+    "placeholder": "Agent"
   },
   "modelSelector": {
     "selectModel": "Modell auswählen",
@@ -268,6 +273,16 @@
     "run": "Ausführen",
     "detectedCommand": "Erkannter Befehl",
     "setupFinished": "Einrichtung abgeschlossen - Worktree ist bereit."
+  },
+  "worktreeCleanup": {
+    "title": "Keine Sitzungen übrig",
+    "descriptionPrefix": "Der Worktree",
+    "branch": "Branch",
+    "descriptionSuffix": "hat keine aktiven Sitzungen. Möchtest du ihn entfernen?",
+    "keep": "Behalten",
+    "remove": "Entfernen",
+    "removing": "Entferne...",
+    "deleteFromDisk": "Worktree-Dateien auch von der Festplatte löschen"
   },
   "providers": {
     "searchPlaceholder": "Anbieter suchen...",
@@ -364,6 +379,13 @@
     "checkingLocalServer": "Lokaler Server wird geprüft...",
     "startingLocalServer": "Lokaler Server wird gestartet..."
   },
+  "updateDialog": {
+    "title": "Update verfügbar",
+    "description": "Eine neue Version von OpenGUI ({{latestVersion}}) ist verfügbar. Aktuell läuft v{{currentVersion}}.",
+    "currentVersion": "Aktuelle Version: v{{currentVersion}}.",
+    "dismiss": "Ausblenden",
+    "open": "Öffnen"
+  },
   "emptyStates": {
     "noProjectTitle": "Kein Projekt verbunden",
     "noProjectCanStart": "Verbinde jetzt ein Projekt oder starte einen Chat.",
@@ -397,6 +419,65 @@
   "diff": {
     "noLineDiffAvailable": "Kein Zeilendiff verfügbar."
   },
+  "reasoning": {
+    "thinking": "Denkt",
+    "thinkingRunning": "Denkt..."
+  },
+  "toolLabels": {
+    "bash": {
+      "running": "Führt aus",
+      "done": "Ausgeführt"
+    },
+    "read": {
+      "running": "Liest",
+      "done": "Gelesen"
+    },
+    "edit": {
+      "running": "Bearbeitet",
+      "done": "Bearbeitet"
+    },
+    "write": {
+      "running": "Schreibt",
+      "done": "Geschrieben"
+    },
+    "grep": {
+      "running": "Sucht",
+      "done": "Gesucht"
+    },
+    "glob": {
+      "running": "Sucht Dateien",
+      "done": "Dateien gesucht"
+    },
+    "task": {
+      "running": "Läuft",
+      "done": "Ausgeführt"
+    },
+    "todo": {
+      "running": "Schreibt Todos",
+      "doneOne": "{{count}} Todo geschrieben",
+      "doneOther": "{{count}} Todos geschrieben"
+    },
+    "question": {
+      "running": "Fragt",
+      "doneOne": "{{count}} Frage gestellt",
+      "doneOther": "{{count}} Fragen gestellt"
+    },
+    "patch": {
+      "created": "Erstellt",
+      "deleted": "Gelöscht",
+      "moved": "Verschoben",
+      "patched": "Gepatcht"
+    },
+    "fileCountOther": "{{count}} Dateien",
+    "matchCountOne": "{{count}} Treffer",
+    "matchCountOther": "{{count}} Treffer"
+  },
+  "attachments": {
+    "image": "Bild",
+    "fileAttachment": "Dateianhang",
+    "imageAttachment": "Bildanhang {{count}}",
+    "closeImagePreview": "Bildvorschau schließen"
+  },
   "projectPath": {
     "up": "Nach oben",
     "noFolders": "Keine Ordner",
@@ -412,7 +493,19 @@
     "loadingServerFolders": "Serverordner werden geladen..."
   },
   "fileMention": {
-    "searching": "Suche..."
+    "searching": "Suche...",
+    "typeToSearch": "Tippe, um Dateien zu suchen",
+    "noMatchingFiles": "Keine passenden Dateien",
+    "searchFailed": "Dateisuche fehlgeschlagen"
+  },
+  "queueList": {
+    "reorderQueuedPrompt": "Nachricht in Warteschlange neu anordnen",
+    "sendNow": "Jetzt senden",
+    "interrupt": "unterbrechen",
+    "steer": "steuern",
+    "edit": "Bearbeiten",
+    "moveToTop": "Nach ganz oben",
+    "moveToBottom": "Nach ganz unten"
   },
   "permissionPanel": {
     "title": "Berechtigung: {{permission}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -133,6 +133,8 @@
     "projects": "Projects",
     "searchPlaceholder": "Search projects and sessions...",
     "showLess": "Show less",
+    "title": "Sidebar",
+    "mobileDescription": "Displays the mobile sidebar.",
     "untitled": "Untitled"
   },
   "sessionMenu": {
@@ -188,6 +190,9 @@
   "variantSelector": {
     "off": "off",
     "thinkingEffort": "Thinking effort: {{level}} (click or Ctrl+T to cycle, Ctrl+Shift+T to cycle backward)"
+  },
+  "agentSelector": {
+    "placeholder": "Agent"
   },
   "modelSelector": {
     "selectModel": "Select model",
@@ -265,6 +270,16 @@
     "run": "Run",
     "detectedCommand": "Detected command",
     "setupFinished": "Setup finished - worktree is ready."
+  },
+  "worktreeCleanup": {
+    "title": "No sessions remaining",
+    "descriptionPrefix": "The worktree",
+    "branch": "branch",
+    "descriptionSuffix": "has no active sessions. Would you like to remove it?",
+    "keep": "Keep",
+    "remove": "Remove",
+    "removing": "Removing...",
+    "deleteFromDisk": "Also delete worktree files from disk"
   },
   "providers": {
     "searchPlaceholder": "Search providers...",
@@ -361,6 +376,13 @@
     "checkingLocalServer": "Checking local server...",
     "startingLocalServer": "Starting local server..."
   },
+  "updateDialog": {
+    "title": "Update Available",
+    "description": "A new version of OpenGUI ({{latestVersion}}) is available. You are currently running v{{currentVersion}}.",
+    "currentVersion": "Current version: v{{currentVersion}}.",
+    "dismiss": "Dismiss",
+    "open": "Open"
+  },
   "emptyStates": {
     "noProjectTitle": "No project connected",
     "noProjectCanStart": "Connect a project now or start a chat.",
@@ -394,6 +416,65 @@
   "diff": {
     "noLineDiffAvailable": "No line diff available."
   },
+  "reasoning": {
+    "thinking": "Thinking",
+    "thinkingRunning": "Thinking..."
+  },
+  "toolLabels": {
+    "bash": {
+      "running": "Running",
+      "done": "Ran"
+    },
+    "read": {
+      "running": "Reading",
+      "done": "Read"
+    },
+    "edit": {
+      "running": "Editing",
+      "done": "Edited"
+    },
+    "write": {
+      "running": "Writing",
+      "done": "Wrote"
+    },
+    "grep": {
+      "running": "Searching",
+      "done": "Searched"
+    },
+    "glob": {
+      "running": "Globbing",
+      "done": "Globbed"
+    },
+    "task": {
+      "running": "Running",
+      "done": "Ran"
+    },
+    "todo": {
+      "running": "Writing todos",
+      "doneOne": "Wrote {{count}} todo",
+      "doneOther": "Wrote {{count}} todos"
+    },
+    "question": {
+      "running": "Asking",
+      "doneOne": "Asked {{count}} question",
+      "doneOther": "Asked {{count}} questions"
+    },
+    "patch": {
+      "created": "Created",
+      "deleted": "Deleted",
+      "moved": "Moved",
+      "patched": "Patched"
+    },
+    "fileCountOther": "{{count}} files",
+    "matchCountOne": "{{count}} match",
+    "matchCountOther": "{{count}} matches"
+  },
+  "attachments": {
+    "image": "Image",
+    "fileAttachment": "File attachment",
+    "imageAttachment": "Image attachment {{count}}",
+    "closeImagePreview": "Close image preview"
+  },
   "projectPath": {
     "up": "Up",
     "noFolders": "No folders",
@@ -409,7 +490,19 @@
     "loadingServerFolders": "Loading server folders..."
   },
   "fileMention": {
-    "searching": "Searching..."
+    "searching": "Searching...",
+    "typeToSearch": "Type to search files",
+    "noMatchingFiles": "No matching files",
+    "searchFailed": "File search failed"
+  },
+  "queueList": {
+    "reorderQueuedPrompt": "Reorder queued prompt",
+    "sendNow": "Send now",
+    "interrupt": "interrupt",
+    "steer": "steer",
+    "edit": "Edit",
+    "moveToTop": "Move to top",
+    "moveToBottom": "Move to bottom"
   },
   "permissionPanel": {
     "title": "Permission: {{permission}}",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -136,6 +136,8 @@
     "projects": "Proyectos",
     "searchPlaceholder": "Buscar proyectos y sesiones...",
     "showLess": "Mostrar menos",
+    "title": "Barra lateral",
+    "mobileDescription": "Muestra la barra lateral móvil.",
     "untitled": "Sin título"
   },
   "sessionMenu": {
@@ -191,6 +193,9 @@
   "variantSelector": {
     "off": "apagado",
     "thinkingEffort": "Esfuerzo de razonamiento: {{level}} (clic o Ctrl+T para cambiar, Ctrl+Mayús+T para retroceder)"
+  },
+  "agentSelector": {
+    "placeholder": "Agente"
   },
   "modelSelector": {
     "selectModel": "Seleccionar modelo",
@@ -268,6 +273,16 @@
     "run": "Ejecutar",
     "detectedCommand": "Comando detectado",
     "setupFinished": "Configuración finalizada - el worktree está listo."
+  },
+  "worktreeCleanup": {
+    "title": "No quedan sesiones",
+    "descriptionPrefix": "El worktree",
+    "branch": "rama",
+    "descriptionSuffix": "no tiene sesiones activas. ¿Quieres eliminarlo?",
+    "keep": "Conservar",
+    "remove": "Eliminar",
+    "removing": "Eliminando...",
+    "deleteFromDisk": "Eliminar también los archivos del worktree del disco"
   },
   "providers": {
     "searchPlaceholder": "Buscar proveedores...",
@@ -364,6 +379,13 @@
     "checkingLocalServer": "Comprobando servidor local...",
     "startingLocalServer": "Iniciando servidor local..."
   },
+  "updateDialog": {
+    "title": "Actualización disponible",
+    "description": "Hay una nueva versión de OpenGUI ({{latestVersion}}) disponible. Actualmente ejecutas v{{currentVersion}}.",
+    "currentVersion": "Versión actual: v{{currentVersion}}.",
+    "dismiss": "Descartar",
+    "open": "Abrir"
+  },
   "emptyStates": {
     "noProjectTitle": "No hay ningún proyecto conectado",
     "noProjectCanStart": "Conecta un proyecto ahora o inicia un chat.",
@@ -397,6 +419,65 @@
   "diff": {
     "noLineDiffAvailable": "No hay diff de líneas disponible."
   },
+  "reasoning": {
+    "thinking": "Pensando",
+    "thinkingRunning": "Pensando..."
+  },
+  "toolLabels": {
+    "bash": {
+      "running": "Ejecutando",
+      "done": "Ejecutado"
+    },
+    "read": {
+      "running": "Leyendo",
+      "done": "Leído"
+    },
+    "edit": {
+      "running": "Editando",
+      "done": "Editado"
+    },
+    "write": {
+      "running": "Escribiendo",
+      "done": "Escrito"
+    },
+    "grep": {
+      "running": "Buscando",
+      "done": "Buscado"
+    },
+    "glob": {
+      "running": "Buscando archivos",
+      "done": "Archivos encontrados"
+    },
+    "task": {
+      "running": "Ejecutando",
+      "done": "Ejecutado"
+    },
+    "todo": {
+      "running": "Escribiendo tareas",
+      "doneOne": "{{count}} tarea escrita",
+      "doneOther": "{{count}} tareas escritas"
+    },
+    "question": {
+      "running": "Preguntando",
+      "doneOne": "{{count}} pregunta hecha",
+      "doneOther": "{{count}} preguntas hechas"
+    },
+    "patch": {
+      "created": "Creado",
+      "deleted": "Eliminado",
+      "moved": "Movido",
+      "patched": "Parcheado"
+    },
+    "fileCountOther": "{{count}} archivos",
+    "matchCountOne": "{{count}} coincidencia",
+    "matchCountOther": "{{count}} coincidencias"
+  },
+  "attachments": {
+    "image": "Imagen",
+    "fileAttachment": "Archivo adjunto",
+    "imageAttachment": "Imagen adjunta {{count}}",
+    "closeImagePreview": "Cerrar vista previa de imagen"
+  },
   "projectPath": {
     "up": "Subir",
     "noFolders": "No hay carpetas",
@@ -412,7 +493,19 @@
     "loadingServerFolders": "Cargando carpetas del servidor..."
   },
   "fileMention": {
-    "searching": "Buscando..."
+    "searching": "Buscando...",
+    "typeToSearch": "Escribe para buscar archivos",
+    "noMatchingFiles": "No hay archivos coincidentes",
+    "searchFailed": "Error al buscar archivos"
+  },
+  "queueList": {
+    "reorderQueuedPrompt": "Reordenar mensaje en cola",
+    "sendNow": "Enviar ahora",
+    "interrupt": "interrumpir",
+    "steer": "dirigir",
+    "edit": "Editar",
+    "moveToTop": "Mover arriba del todo",
+    "moveToBottom": "Mover abajo del todo"
   },
   "permissionPanel": {
     "title": "Permiso: {{permission}}",


### PR DESCRIPTION
## Summary
- Move tool, reasoning, attachment, queue, sidebar, update, and worktree cleanup UI labels into i18n files
- Add matching English, German, and Spanish translations
- Fix duplicate locale sidebar keys so existing sidebar labels resolve correctly

## Checks
- Locale JSON parse + duplicate top-level key check
- vp check (passes with existing pi-bridge await-thenable warnings)