### PR TITLE
Allow creating folders in directory picker

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -534,10 +534,10 @@ ipcMain.handle("dialog:openDirectory", async (event) => {
   const ownerWindow = BrowserWindow.fromWebContents(event.sender) ?? mainWindow;
   const result = ownerWindow
     ? await dialog.showOpenDialog(ownerWindow, {
-        properties: ["openDirectory"],
+        properties: ["openDirectory", "createDirectory"],
       })
     : await dialog.showOpenDialog({
-        properties: ["openDirectory"],
+        properties: ["openDirectory", "createDirectory"],
       });
   if (result.canceled || result.filePaths.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
- enable Electron's createDirectory option for native directory picker
- keeps existing folder selection behavior unchanged

## Checks
- vp check passed in main worktree before PR