### PR TITLE
Add clickable workspace paths and web links

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const { app, BrowserWindow, dialog, ipcMain, shell, session } =
   require("electron") as typeof import("electron");
+import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { execSync, spawn } from "node:child_process";
 import type { SpawnOptions } from "node:child_process";
@@ -60,6 +61,38 @@ function spawnCustomCommand(command: unknown, options: SpawnOptions = {}) {
   child.on("error", () => {});
   child.unref();
   return true;
+}
+
+function cleanOpenPath(value: unknown) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^["']|["']$/g, "");
+}
+
+function isPathInside(candidate: string, parent: string) {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function resolveFileTarget(filePath: unknown, baseDirectory?: unknown) {
+  const target = cleanOpenPath(filePath);
+  if (!target || target.includes("\0")) return null;
+
+  const base = cleanOpenPath(baseDirectory);
+  const normalizedBase = base ? path.resolve(base) : null;
+  if (!normalizedBase) return null;
+
+  const isAbsolute = path.isAbsolute(target) || path.win32.isAbsolute(target);
+  const resolved = isAbsolute ? path.resolve(target) : path.resolve(normalizedBase, target);
+  if (normalizedBase && !isPathInside(resolved, normalizedBase)) return null;
+
+  try {
+    if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
 }
 
 function getDesktopTerminalCommand() {
@@ -481,6 +514,24 @@ ipcMain.handle("platform:harnessInventory", () => getHarnessInventories());
 // Open a URL in the system browser (not in Electron)
 ipcMain.handle("shell:openExternal", (_event, url) => {
   if (isWebUrl(url)) void shell.openExternal(url);
+});
+
+ipcMain.handle("shell:fileExists", (_event, filePath, baseDirectory) => {
+  return !!resolveFileTarget(filePath, baseDirectory);
+});
+
+ipcMain.handle("shell:openFile", async (_event, filePath, baseDirectory) => {
+  const target = resolveFileTarget(filePath, baseDirectory);
+  if (!target) return false;
+  const error = await shell.openPath(target);
+  return !error;
+});
+
+ipcMain.handle("shell:showFileInFolder", (_event, filePath, baseDirectory) => {
+  const target = resolveFileTarget(filePath, baseDirectory);
+  if (!target) return false;
+  shell.showItemInFolder(target);
+  return true;
 });
 
 // Open a directory in the system file browser

--- a/preload.ts
+++ b/preload.ts
@@ -113,6 +113,9 @@ const electronAPI: ElectronAPI = {
   },
 
   openExternal: invoke("shell:openExternal"),
+  fileExists: invoke("shell:fileExists"),
+  openFile: invoke("shell:openFile"),
+  showFileInFolder: invoke("shell:showFileInFolder"),
   updates: {
     getState: async () => disabledUpdateState,
     check: async () => disabledUpdateState,

--- a/server/shell-ipc-handlers.ts
+++ b/server/shell-ipc-handlers.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, win32 } from "node:path";
 import { homedir } from "node:os";
 import type { BackendServiceContext } from "./services/index.ts";
 import { getHarnessInventories } from "./harness-inventory.ts";
@@ -52,6 +53,45 @@ function openPath(path: string) {
   if (process.platform === "darwin") spawnDetached("open", [path]);
   else if (process.platform === "win32") spawnDetached("explorer.exe", [path]);
   else spawnDetached("xdg-open", [path]);
+}
+
+function showFileInFolder(path: string) {
+  if (process.platform === "darwin") spawnDetached("open", ["-R", path]);
+  else if (process.platform === "win32") spawnDetached("explorer.exe", [`/select,${path}`]);
+  else openPath(dirname(path));
+}
+
+function cleanOpenPath(value: unknown) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^["']|["']$/g, "");
+}
+
+function isPathInside(candidate: string, parent: string) {
+  const childRelative = relative(parent, candidate);
+  return (
+    childRelative === "" ||
+    (!!childRelative && !childRelative.startsWith("..") && !isAbsolute(childRelative))
+  );
+}
+
+function resolveFileTarget(filePath: unknown, baseDirectory?: unknown) {
+  const target = cleanOpenPath(filePath);
+  if (!target || target.includes("\0")) return null;
+
+  const base = cleanOpenPath(baseDirectory);
+  const normalizedBase = base ? resolve(base) : null;
+  if (!normalizedBase) return null;
+
+  const targetAbsolute = isAbsolute(target) || win32.isAbsolute(target);
+  const resolved = targetAbsolute ? resolve(target) : resolve(normalizedBase, target);
+  if (normalizedBase && !isPathInside(resolved, normalizedBase)) return null;
+
+  try {
+    if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
 }
 
 async function runPicker(command: string[]) {
@@ -189,6 +229,21 @@ export function registerShellIpcHandlers(input: {
   ipcMain.handle("shell:openExternal", (_event, url) =>
     openExternal(typeof url === "string" ? url : ""),
   );
+  ipcMain.handle("shell:fileExists", (_event, filePath, baseDirectory) => {
+    return !!resolveFileTarget(filePath, baseDirectory);
+  });
+  ipcMain.handle("shell:openFile", (_event, filePath, baseDirectory) => {
+    const target = resolveFileTarget(filePath, baseDirectory);
+    if (!target) return false;
+    openPath(target);
+    return true;
+  });
+  ipcMain.handle("shell:showFileInFolder", (_event, filePath, baseDirectory) => {
+    const target = resolveFileTarget(filePath, baseDirectory);
+    if (!target) return false;
+    showFileInFolder(target);
+    return true;
+  });
   ipcMain.handle("shell:openInFileBrowser", (_event, dirPath, command = "") => {
     const dir = typeof dirPath === "string" ? dirPath : "";
     if (!dir) return;

--- a/src/components/FilePathToken.tsx
+++ b/src/components/FilePathToken.tsx
@@ -1,0 +1,94 @@
+import { ExternalLink } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { getShellKind } from "@/runtime/shell-policy";
+import { cleanFilePathToken } from "@/lib/file-paths";
+import { cn, copyTextToClipboard, getErrorMessage } from "@/lib/utils";
+
+export function FilePathToken({
+  path,
+  baseDirectory,
+  className,
+}: {
+  path: string;
+  baseDirectory?: string | null;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const filePath = cleanFilePathToken(path);
+  const shellKind = getShellKind();
+  const canUseShell = !!window.electronAPI?.openFile;
+  const [exists, setExists] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setExists(false);
+
+    if (!baseDirectory || shellKind === "mobile" || !window.electronAPI?.fileExists) return;
+
+    window.electronAPI
+      .fileExists(filePath, baseDirectory)
+      .then((result) => {
+        if (!cancelled) setExists(result);
+      })
+      .catch(() => {
+        if (!cancelled) setExists(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseDirectory, filePath, shellKind]);
+
+  const copyPathFallback = async (messageKey: string) => {
+    await copyTextToClipboard(filePath);
+    toast.info(t(messageKey));
+  };
+
+  const handleOpen = async () => {
+    if (shellKind === "mobile") {
+      await copyPathFallback("fileActions.mobileUnavailable");
+      return;
+    }
+
+    if (!canUseShell) {
+      await copyPathFallback("fileActions.openUnavailable");
+      return;
+    }
+
+    try {
+      const opened = await window.electronAPI?.openFile?.(filePath, baseDirectory ?? undefined);
+      if (!opened) {
+        await copyPathFallback("fileActions.openFailedCopied");
+      }
+    } catch (error) {
+      await copyTextToClipboard(filePath);
+      toast.error(getErrorMessage(error, t("fileActions.openFailedCopied")));
+    }
+  };
+
+  if (!exists) {
+    return (
+      <code className="rounded bg-muted px-[0.3rem] py-[0.1rem] font-mono text-[0.85em] font-medium">
+        {path}
+      </code>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex max-w-full cursor-pointer items-center gap-1 rounded bg-muted px-[0.3rem] py-[0.1rem] align-baseline font-mono text-[0.85em] font-medium text-foreground transition-colors hover:bg-muted/80 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={handleOpen}
+      title={t("fileActions.openFile")}
+      aria-label={t("fileActions.openFile")}
+    >
+      <span className="truncate">{path}</span>
+      {shellKind !== "mobile" && <ExternalLink className="size-3 shrink-0 opacity-60" />}
+    </button>
+  );
+}

--- a/src/components/LinkToken.tsx
+++ b/src/components/LinkToken.tsx
@@ -1,0 +1,31 @@
+import { ExternalLink } from "lucide-react";
+import type { MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { cn, openExternalLink } from "@/lib/utils";
+
+export function LinkToken({ url, className }: { url: string; className?: string }) {
+  const { t } = useTranslation();
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    openExternalLink(url);
+  };
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "inline-flex max-w-full items-center gap-1 rounded bg-muted px-[0.3rem] py-[0.1rem] align-baseline font-mono text-[0.85em] font-medium text-foreground transition-colors hover:bg-muted/80 hover:text-primary hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={handleClick}
+      title={t("fileActions.openLink")}
+      aria-label={t("fileActions.openLink")}
+    >
+      <span className="truncate">{url}</span>
+      <ExternalLink className="size-3 shrink-0 opacity-60" />
+    </a>
+  );
+}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -14,7 +14,9 @@ import {
 import ReactMarkdown from "react-markdown";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
 import remarkGfm from "remark-gfm";
+import { FilePathToken } from "@/components/FilePathToken";
 import { Button } from "@/components/ui/button";
+import { isFilePathLike } from "@/lib/file-paths";
 import { cn, copyTextToClipboard, openExternalLink } from "@/lib/utils";
 
 type StarryNight = Awaited<ReturnType<typeof createStarryNight>>;
@@ -141,62 +143,83 @@ function StarryCodeBlock({ children, className }: ComponentProps<"code">) {
   );
 }
 
-const markdownComponents = {
-  table({ children, node: _node, ...props }: ComponentProps<"table"> & { node?: unknown }) {
-    return (
-      <div className="markdown-table-scroll">
-        <table {...props}>{children}</table>
-      </div>
-    );
-  },
-  pre({ children }: ComponentProps<"pre">) {
-    // react-markdown applies component mappings before passing children to `pre`,
-    // so the child type is our mapped `code` function, not the literal "code" tag.
-    // Treat any single React element child with code-like props as a fenced block.
-    if (isValidElement<ComponentProps<"code">>(children)) {
+function createMarkdownComponents(baseDirectory?: string | null) {
+  return {
+    table({ children, node: _node, ...props }: ComponentProps<"table"> & { node?: unknown }) {
       return (
-        <StarryCodeBlock className={children.props.className}>
-          {children.props.children}
-        </StarryCodeBlock>
+        <div className="markdown-table-scroll">
+          <table {...props}>{children}</table>
+        </div>
       );
-    }
+    },
+    pre({ children }: ComponentProps<"pre">) {
+      // react-markdown applies component mappings before passing children to `pre`,
+      // so the child type is our mapped `code` function, not the literal "code" tag.
+      // Treat any single React element child with code-like props as a fenced block.
+      if (isValidElement<ComponentProps<"code">>(children)) {
+        return (
+          <StarryCodeBlock className={children.props.className}>
+            {children.props.children}
+          </StarryCodeBlock>
+        );
+      }
 
-    return <pre>{children}</pre>;
-  },
-  a({ children, href, node: _node, ...props }: ComponentProps<"a"> & { node?: unknown }) {
-    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-      if (!href) return;
-      event.preventDefault();
-      openExternalLink(href);
-    };
+      return <pre>{children}</pre>;
+    },
+    a({ children, href, node: _node, ...props }: ComponentProps<"a"> & { node?: unknown }) {
+      if (href && isFilePathLike(href)) {
+        return <FilePathToken path={href} baseDirectory={baseDirectory} />;
+      }
 
-    return (
-      <a
-        {...props}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-primary hover:underline"
-        onClick={handleClick}
-      >
-        {children}
-      </a>
-    );
-  },
-  code({ children, node: _node, ...props }: ComponentProps<"code"> & { node?: unknown }) {
-    return (
-      <code
-        {...props}
-        className="rounded bg-muted px-[0.3rem] py-[0.1rem] font-mono text-[0.85em] font-medium"
-      >
-        {children}
-      </code>
-    );
-  },
-};
+      const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+        if (!href) return;
+        event.preventDefault();
+        openExternalLink(href);
+      };
 
-export const MarkdownRenderer = memo(function MarkdownRenderer({ content }: { content: string }) {
+      return (
+        <a
+          {...props}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+          onClick={handleClick}
+        >
+          {children}
+        </a>
+      );
+    },
+    code({ children, node: _node, ...props }: ComponentProps<"code"> & { node?: unknown }) {
+      const value = nodeToString(children);
+      if (!props.className && isFilePathLike(value)) {
+        return <FilePathToken path={value} baseDirectory={baseDirectory} />;
+      }
+
+      return (
+        <code
+          {...props}
+          className="rounded bg-muted px-[0.3rem] py-[0.1rem] font-mono text-[0.85em] font-medium"
+        >
+          {children}
+        </code>
+      );
+    },
+  };
+}
+
+export const MarkdownRenderer = memo(function MarkdownRenderer({
+  content,
+  baseDirectory,
+}: {
+  content: string;
+  baseDirectory?: string | null;
+}) {
   const remarkPlugins = useMemo(() => [remarkGfm], []);
+  const markdownComponents = useMemo(
+    () => createMarkdownComponents(baseDirectory),
+    [baseDirectory],
+  );
 
   return (
     <div className="markdown-renderer text-sm leading-relaxed select-text">

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -15,8 +15,10 @@ import ReactMarkdown from "react-markdown";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
 import remarkGfm from "remark-gfm";
 import { FilePathToken } from "@/components/FilePathToken";
+import { LinkToken } from "@/components/LinkToken";
 import { Button } from "@/components/ui/button";
 import { isFilePathLike } from "@/lib/file-paths";
+import { isWebUrl } from "@/lib/urls";
 import { cn, copyTextToClipboard, openExternalLink } from "@/lib/utils";
 
 type StarryNight = Awaited<ReturnType<typeof createStarryNight>>;
@@ -170,6 +172,9 @@ function createMarkdownComponents(baseDirectory?: string | null) {
       if (href && isFilePathLike(href)) {
         return <FilePathToken path={href} baseDirectory={baseDirectory} />;
       }
+      if (isWebUrl(href) && nodeToString(children) === href) {
+        return <LinkToken url={href} />;
+      }
 
       const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
         if (!href) return;
@@ -192,6 +197,9 @@ function createMarkdownComponents(baseDirectory?: string | null) {
     },
     code({ children, node: _node, ...props }: ComponentProps<"code"> & { node?: unknown }) {
       const value = nodeToString(children);
+      if (!props.className && isWebUrl(value)) {
+        return <LinkToken url={value} />;
+      }
       if (!props.className && isFilePathLike(value)) {
         return <FilePathToken path={value} baseDirectory={baseDirectory} />;
       }

--- a/src/components/message-list/TextPartView.tsx
+++ b/src/components/message-list/TextPartView.tsx
@@ -48,7 +48,7 @@ export function TextPartView({
 
   return (
     <div>
-      <MarkdownRenderer content={part.text} />
+      <MarkdownRenderer content={part.text} baseDirectory={imageBaseDirectory} />
     </div>
   );
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -168,6 +168,7 @@
   },
   "fileActions": {
     "openFile": "Datei öffnen",
+    "openLink": "Link öffnen",
     "mobileUnavailable": "Lokale Workspace-Dateien können auf Mobilgeräten nicht geöffnet werden. Pfad kopiert.",
     "openUnavailable": "Dateien können hier nicht geöffnet werden. Pfad kopiert.",
     "openFailedCopied": "Datei konnte nicht geöffnet werden. Pfad kopiert."

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -166,6 +166,12 @@
     "closeOtherProjects": "Andere Projekte schließen",
     "createPullRequest": "PR erstellen"
   },
+  "fileActions": {
+    "openFile": "Datei öffnen",
+    "mobileUnavailable": "Lokale Workspace-Dateien können auf Mobilgeräten nicht geöffnet werden. Pfad kopiert.",
+    "openUnavailable": "Dateien können hier nicht geöffnet werden. Pfad kopiert.",
+    "openFailedCopied": "Datei konnte nicht geöffnet werden. Pfad kopiert."
+  },
   "prompt": {
     "inputLabel": "Nachrichteneingabe",
     "selectOrCreateSession": "Sitzung auswählen oder erstellen...",
@@ -363,6 +369,11 @@
   "startup": {
     "checkingLocalServer": "Lokaler Server wird geprüft...",
     "startingLocalServer": "Lokaler Server wird gestartet..."
+  },
+  "sessionError": {
+    "title": "Agentenfehler",
+    "nextStep": "Nächster Schritt: Führe diesen Befehl im Terminal aus und versuche es erneut:",
+    "openTerminal": "Terminal öffnen"
   },
   "emptyStates": {
     "noProjectTitle": "Kein Projekt verbunden",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -163,6 +163,12 @@
     "closeOtherProjects": "Close other projects",
     "createPullRequest": "Create PR"
   },
+  "fileActions": {
+    "openFile": "Open file",
+    "mobileUnavailable": "Opening local workspace files is not available on mobile. Path copied.",
+    "openUnavailable": "Opening files is not available here. Path copied.",
+    "openFailedCopied": "Could not open file. Path copied."
+  },
   "prompt": {
     "inputLabel": "Message input",
     "selectOrCreateSession": "Select or create a session...",
@@ -360,6 +366,11 @@
   "startup": {
     "checkingLocalServer": "Checking local server...",
     "startingLocalServer": "Starting local server..."
+  },
+  "sessionError": {
+    "title": "Agent error",
+    "nextStep": "Next step: run this command in your terminal, then retry:",
+    "openTerminal": "Open terminal"
   },
   "emptyStates": {
     "noProjectTitle": "No project connected",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -165,6 +165,7 @@
   },
   "fileActions": {
     "openFile": "Open file",
+    "openLink": "Open link",
     "mobileUnavailable": "Opening local workspace files is not available on mobile. Path copied.",
     "openUnavailable": "Opening files is not available here. Path copied.",
     "openFailedCopied": "Could not open file. Path copied."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -166,6 +166,12 @@
     "closeOtherProjects": "Cerrar otros proyectos",
     "createPullRequest": "Crear PR"
   },
+  "fileActions": {
+    "openFile": "Abrir archivo",
+    "mobileUnavailable": "Abrir archivos locales del workspace no está disponible en móvil. Ruta copiada.",
+    "openUnavailable": "Abrir archivos no está disponible aquí. Ruta copiada.",
+    "openFailedCopied": "No se pudo abrir el archivo. Ruta copiada."
+  },
   "prompt": {
     "inputLabel": "Entrada de mensaje",
     "selectOrCreateSession": "Selecciona o crea una sesión...",
@@ -363,6 +369,11 @@
   "startup": {
     "checkingLocalServer": "Comprobando servidor local...",
     "startingLocalServer": "Iniciando servidor local..."
+  },
+  "sessionError": {
+    "title": "Error del agente",
+    "nextStep": "Siguiente paso: ejecuta este comando en tu terminal y vuelve a intentarlo:",
+    "openTerminal": "Abrir terminal"
   },
   "emptyStates": {
     "noProjectTitle": "No hay ningún proyecto conectado",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -168,6 +168,7 @@
   },
   "fileActions": {
     "openFile": "Abrir archivo",
+    "openLink": "Abrir enlace",
     "mobileUnavailable": "Abrir archivos locales del workspace no está disponible en móvil. Ruta copiada.",
     "openUnavailable": "Abrir archivos no está disponible aquí. Ruta copiada.",
     "openFailedCopied": "No se pudo abrir el archivo. Ruta copiada."

--- a/src/lib/file-paths.ts
+++ b/src/lib/file-paths.ts
@@ -1,0 +1,22 @@
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/;
+const UNC_PATH_RE = /^\\\\[^\\/]+[\\/][^\\/]+/;
+const FILE_EXTENSION_RE = /(^|[\\/])[^\\/<>:"|?*\n\r]+\.[A-Za-z0-9]{1,12}$/;
+
+export function cleanFilePathToken(value: string) {
+  return value.trim().replace(/^["']|["']$/g, "");
+}
+
+export function isAbsolutePathLike(value: string) {
+  return value.startsWith("/") || WINDOWS_ABSOLUTE_PATH_RE.test(value) || UNC_PATH_RE.test(value);
+}
+
+export function isFilePathLike(value: string) {
+  const cleaned = cleanFilePathToken(value);
+  if (!cleaned || cleaned.length > 1024) return false;
+  if (cleaned.includes("\n") || cleaned.includes("\r") || cleaned.includes("\u0000")) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleaned) && !WINDOWS_ABSOLUTE_PATH_RE.test(cleaned)) return false;
+  if (!cleaned.includes("/") && !cleaned.includes("\\")) return false;
+  if (!FILE_EXTENSION_RE.test(cleaned)) return false;
+  if (/^[-–—]/.test(cleaned)) return false;
+  return true;
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,9 @@
+export function isWebUrl(value: unknown): value is string {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/web-electron-api.ts
+++ b/src/lib/web-electron-api.ts
@@ -159,6 +159,12 @@ export function installWebElectronAPI() {
     getDetachedProjects: () => invoke("window:getDetachedProjects"),
     onDetachedProjectsChange: () => () => {},
     openExternal: (url: string) => invoke("shell:openExternal", url),
+    fileExists: (filePath: string, baseDirectory?: string) =>
+      invoke("shell:fileExists", filePath, baseDirectory),
+    openFile: (filePath: string, baseDirectory?: string) =>
+      invoke("shell:openFile", filePath, baseDirectory),
+    showFileInFolder: (filePath: string, baseDirectory?: string) =>
+      invoke("shell:showFileInFolder", filePath, baseDirectory),
     updates: {
       getState: async () => ({ status: "idle" }),
       check: async () => undefined,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -422,6 +422,15 @@ export interface ElectronAPI {
   openExternal: (url: string) => Promise<void>;
   updates: UpdatesBridge;
 
+  /** Check whether a file exists. Relative paths are resolved against baseDirectory. */
+  fileExists?: (filePath: string, baseDirectory?: string) => Promise<boolean>;
+
+  /** Open a file with the system default application. Relative paths are resolved against baseDirectory. */
+  openFile?: (filePath: string, baseDirectory?: string) => Promise<boolean>;
+
+  /** Reveal a file in the system file browser. Relative paths are resolved against baseDirectory. */
+  showFileInFolder?: (filePath: string, baseDirectory?: string) => Promise<boolean>;
+
   /** Open a directory in the system file browser (Finder / Explorer / Nautilus). */
   openInFileBrowser: (dirPath: string, command?: string) => Promise<void>;
 


### PR DESCRIPTION
## Summary\n- Render existing inline workspace file paths as clickable chips\n- Render inline http/https code URLs as clickable link chips\n- Add Electron/web-local IPC/RPC handlers to validate and open/reveal files\n- Fall back to plain code labels or copy behavior on unsupported runtimes\n\n## Checks\n- vp check (passes locally)\n- vp check on PR worktree: only existing master warnings in pi-bridge.ts