### PR TITLE
Fix Windows harness CLI resolution

### DIFF
--- a/server/harness-inventory.ts
+++ b/server/harness-inventory.ts
@@ -23,23 +23,27 @@ export function isHarnessId(value: unknown): value is ActiveHarnessId {
   return typeof value === "string" && HARNESS_IDS.includes(value as ActiveHarnessId);
 }
 
-function binaryName(command: string) {
-  return process.platform === "win32" && !command.endsWith(".exe") ? `${command}.exe` : command;
+function binaryNames(command: string) {
+  if (process.platform !== "win32") return [command];
+  if (/\.(?:exe|cmd|bat|ps1)$/i.test(command)) return [command];
+  return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, `${command}.ps1`, command];
 }
 
 function commonBinaryPaths(command: string): string[] {
-  const bin = binaryName(command);
+  const bins = binaryNames(command);
   const home = homedir();
-  return [
-    ...(command === "opencode" ? [join(home, ".opencode", "bin", bin)] : []),
-    join(home, ".claude", "local", bin),
-    join(home, ".local", "bin", bin),
-    join(home, ".bun", "bin", bin),
-    join(home, "Library", "pnpm", bin),
-    "/opt/homebrew/bin/" + bin,
-    "/usr/local/bin/" + bin,
-    "/usr/bin/" + bin,
+  const directories = [
+    ...(command === "opencode" ? [join(home, ".opencode", "bin")] : []),
+    join(home, ".claude", "local"),
+    join(home, ".local", "bin"),
+    join(home, ".bun", "bin"),
+    join(home, "Library", "pnpm"),
+    join(home, "AppData", "Roaming", "npm"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
   ];
+  return directories.flatMap((directory) => bins.map((bin) => join(directory, bin)));
 }
 
 function commandFromShell(command: string): string | null {
@@ -76,7 +80,12 @@ export function resolveHarnessCli(harnessId: ActiveHarnessId): HarnessInventoryC
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    const candidate = result.stdout?.split(/\r?\n/)[0]?.trim();
+    const candidates = (result.stdout ?? "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort((left, right) => windowsCliPriority(left) - windowsCliPriority(right));
+    const candidate = candidates[0];
     if (candidate)
       return { command, resolvedPath: candidate, checkedPaths: [...checkedPaths, "where"] };
   }
@@ -84,13 +93,31 @@ export function resolveHarnessCli(harnessId: ActiveHarnessId): HarnessInventoryC
   return { command, resolvedPath: null, checkedPaths };
 }
 
-function readVersion(resolvedPath: string): string | null {
-  const result = spawnSync(resolvedPath, ["--version"], {
-    cwd: safeDiagnosticCwd(),
-    encoding: "utf8",
-    timeout: 5000,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+function windowsCliPriority(path: string) {
+  if (/\.cmd$/i.test(path)) return 0;
+  if (/\.exe$/i.test(path)) return 1;
+  if (/\.bat$/i.test(path)) return 2;
+  if (!/\.[^\\/]+$/i.test(path)) return 3;
+  if (/\.ps1$/i.test(path)) return 4;
+  return 5;
+}
+
+function readVersion(command: string, resolvedPath: string): string | null {
+  const isWindowsScript = /\.(?:cmd|bat)$/i.test(resolvedPath);
+  const result =
+    process.platform === "win32" && isWindowsScript
+      ? spawnSync("cmd.exe", ["/d", "/c", `${command} --version`], {
+          cwd: safeDiagnosticCwd(),
+          encoding: "utf8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "pipe"],
+        })
+      : spawnSync(resolvedPath, ["--version"], {
+          cwd: safeDiagnosticCwd(),
+          encoding: "utf8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
   if (result.error || result.status !== 0) return null;
   return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim().split(/\r?\n/)[0]?.trim() || null;
 }
@@ -115,7 +142,24 @@ export function getHarnessInventory(harnessId: ActiveHarnessId): HarnessInventor
     };
   }
 
-  const version = readVersion(cli.resolvedPath);
+  const version = readVersion(cli.command, cli.resolvedPath);
+  if (!version) {
+    return {
+      harnessId,
+      displayName: HARNESS_LABELS[harnessId],
+      enabled: true,
+      installed: false,
+      status: "error",
+      auth: { status: "unknown" },
+      version: null,
+      models: [],
+      agents: [],
+      message: `${HARNESS_LABELS[harnessId]} CLI was found at ${basename(cli.resolvedPath)}, but it could not be executed.`,
+      checkedAt,
+      diagnostics: { cli },
+    };
+  }
+
   return {
     harnessId,
     displayName: HARNESS_LABELS[harnessId],


### PR DESCRIPTION
## Summary
- probe Windows CLI wrappers (.cmd/.bat/.ps1/.exe) in common install paths
- prefer executable wrapper paths returned by where
- report found-but-not-executable harness CLIs as diagnostics errors

## Checks
- vp check