### PR TITLE
fix: improve session timestamps and sidebar sort order

### DIFF
--- a/BetterSDK/src/sessions.ts
+++ b/BetterSDK/src/sessions.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createHash, randomUUID } from "node:crypto";
@@ -62,6 +62,7 @@ export async function getSessionInfo(
   sessionId: string,
   opts: { dir?: string } = {},
 ): Promise<SessionInfo | null> {
+  const file = sessionFile(sessionId, opts.dir);
   const messages = await getSessionMessages(sessionId, {
     dir: opts.dir,
     includeSystemMessages: true,
@@ -71,6 +72,9 @@ export async function getSessionInfo(
     last = messages[messages.length - 1] as any;
   const firstUser = messages.find((m: any) => m.type === "user") as any;
   const firstPrompt = contentText(firstUser?.message?.content);
+  const fileMtime = await stat(file)
+    .then((s) => s.mtimeMs)
+    .catch(() => undefined);
   return {
     sessionId,
     summary: first?.summary ?? firstPrompt?.slice(0, 80),
@@ -78,8 +82,8 @@ export async function getSessionInfo(
     customTitle: first?.customTitle,
     cwd: first?.cwd ?? opts.dir,
     model: last?.message?.model ?? first?.model,
-    createdAt: timestamp(first) ?? Date.now(),
-    lastModified: timestamp(last) ?? Date.now(),
+    createdAt: firstTimestampInMessages(messages) ?? fileMtime ?? Date.now(),
+    lastModified: lastTimestampInMessages(messages) ?? fileMtime ?? Date.now(),
   };
 }
 
@@ -125,6 +129,22 @@ export async function forkSession(
     kept.map((m) => JSON.stringify({ ...m, session_id: newId })).join("\n") + "\n",
   );
   return { sessionId: newId };
+}
+
+function firstTimestampInMessages(messages: any[]): number | undefined {
+  for (const m of messages) {
+    const t = timestamp(m);
+    if (t !== undefined) return t;
+  }
+  return undefined;
+}
+
+function lastTimestampInMessages(messages: any[]): number | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const t = timestamp(messages[i]);
+    if (t !== undefined) return t;
+  }
+  return undefined;
 }
 
 function timestamp(m: any): number | undefined {

--- a/src/components/sidebar/use-sidebar-model.test.ts
+++ b/src/components/sidebar/use-sidebar-model.test.ts
@@ -16,14 +16,14 @@ function session(id: string, harnessId: HarnessId, updated: number): Session {
 }
 
 describe("sortSessionsForSidebar", () => {
-  test("keeps preferred Harness sessions above newer sessions from other Harnesses", () => {
+  test("sorts by newest update regardless of Harness", () => {
     const sorted = sortSessionsForSidebar(
       [session("claude-new", "claude-code", 20), session("open-old", "opencode", 10)],
       {},
       "opencode",
     );
 
-    expect(sorted.map((item) => item.id)).toEqual(["open-old", "claude-new"]);
+    expect(sorted.map((item) => item.id)).toEqual(["claude-new", "open-old"]);
   });
 
   test("sorts by newest update inside the same Harness", () => {

--- a/src/components/sidebar/use-sidebar-model.ts
+++ b/src/components/sidebar/use-sidebar-model.ts
@@ -13,7 +13,7 @@ import {
 } from "@/lib/worktree-placement";
 import { getProjectName, normalizeProjectPath } from "@/lib/utils";
 import type { ConnectionStatus, Workspace } from "@/types/electron";
-import { getSessionHarnessId, parseProjectKey } from "@/hooks/agent-session-utils";
+import { parseProjectKey } from "@/hooks/agent-session-utils";
 import type { HarnessId } from "@/agents";
 
 function getSidebarSessionSortTime(session: Session, sessionMeta: SessionMetaMap) {
@@ -46,15 +46,9 @@ export function shouldShowSessionInChatList({
 export function sortSessionsForSidebar(
   items: Session[],
   sessionMeta: SessionMetaMap,
-  preferredHarnessId?: HarnessId | null,
+  _preferredHarnessId?: HarnessId | null,
 ) {
   return [...items].sort((a, b) => {
-    if (preferredHarnessId) {
-      const aPreferred = getSessionHarnessId(a) === preferredHarnessId;
-      const bPreferred = getSessionHarnessId(b) === preferredHarnessId;
-      if (aPreferred !== bPreferred) return aPreferred ? -1 : 1;
-    }
-
     const byUpdated =
       getSidebarSessionSortTime(b, sessionMeta) - getSidebarSessionSortTime(a, sessionMeta);
     if (byUpdated !== 0) return byUpdated;


### PR DESCRIPTION
## Summary

- **Session timestamps:** `getSessionInfo` now derives `createdAt` and `lastModified` from the first/last message timestamps, with file `mtime` as fallback instead of defaulting to `Date.now()`.
- **Sidebar sorting:** Sessions are sorted by newest update across all Harnesses. The previous behavior that pinned the active Harness to the top is removed.

## Test plan

- [x] `sortSessionsForSidebar` unit test updated for cross-Harness sorting
- [ ] Verify sidebar shows sessions in correct chronological order with mixed Harnesses
- [ ] Verify session list timestamps reflect actual message/file times