### PR TITLE
fix: add try/catch for SSE JSON parsing and tighten CORS default

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -416,7 +416,11 @@ async function subscribeBackendEventsForWebContents(webContents: WebContents) {
             .map((line) => line.slice("data: ".length))
             .join("\n");
           if (data && !webContents.isDestroyed()) {
-            webContents.send("backend:event", JSON.parse(data));
+            try {
+              webContents.send("backend:event", JSON.parse(data));
+            } catch {
+              console.warn("Skipping malformed SSE event from backend");
+            }
           }
           boundary = buffer.indexOf("\n\n");
         }

--- a/main/backend-sidecar.ts
+++ b/main/backend-sidecar.ts
@@ -328,7 +328,7 @@ export function createBackendSidecarController(options: CreateBackendSidecarCont
         OPENGUI_AUTH_TOKEN: token,
         OPENGUI_ALLOWED_ROOTS: process.env.OPENGUI_ALLOWED_ROOTS || dependencies.homedir(),
         OPENGUI_DATA_DIR: dataDir,
-        OPENGUI_CORS_ORIGIN: process.env.OPENGUI_CORS_ORIGIN || "*",
+        OPENGUI_CORS_ORIGIN: process.env.OPENGUI_CORS_ORIGIN || "http://localhost:3000",
         OPENGUI_MODE: "desktop-sidecar",
         OPENGUI_SERVER_MODE: "desktop-sidecar",
       },


### PR DESCRIPTION
## Changes
- Wrap JSON.parse(data) in try/catch in SSE event handler to prevent Electron crash on malformed data
- Change CORS default from wildcard * to http://localhost:3000

## Why
Malformed SSE data from the backend would crash the entire Electron main process. The wildcard CORS allows any origin to make requests, which is a security concern.