### PR TITLE
Fix duplicate macOS release manifest upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,4 +294,10 @@ jobs:
           fi
           args=("$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes)
           [[ "$GITHUB_REF_NAME" == *-* ]] && args+=(--prerelease)
-          gh release create "${args[@]}" candidate/SHA256SUMS.txt $(find candidate/artifacts -type f ! -name 'latest-mac-*.yml' -print)
+          mapfile -d '' assets < <(
+            find candidate/artifacts -type f ! -name 'latest-mac*.yml' -print0 | sort -z
+          )
+          # Both architecture jobs emit latest-mac.yml. Upload only the merged manifest produced
+          # in desktop-mac-x64 so GitHub never receives two assets with the same basename.
+          assets+=(candidate/artifacts/desktop-mac-x64/latest-mac.yml)
+          gh release create "${args[@]}" candidate/SHA256SUMS.txt "${assets[@]}"


### PR DESCRIPTION
## Summary

- prevent duplicate `latest-mac.yml` uploads when publishing a GitHub Release
- upload only the merged macOS updater manifest while retaining both architecture packages

## Evidence

The v0.6.0-rc.1 tag workflow built and validated every artifact and published Docker successfully, but GitHub Release creation failed with `ReleaseAsset.name already exists` for `latest-mac.yml`.

This is release automation only; no product code or artifact contents change.