### PR TITLE
Fix packaged Desktop Photon WASM and prepare rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0-rc.2 — release candidate
+
+- Fixed Linux and other packaged Desktop builds failing to start the Host sidecar because Photon’s
+  WebAssembly runtime was not unpacked beside `dist-electron/backend.js`.
+
 ## 0.6.0-rc.1 — release candidate
 
 This candidate replaces the external coding-agent integration architecture with the first-party

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,7 +15,7 @@ curl --fail http://127.0.0.1:${PORT:-4839}/api/health
 For this prerelease, select the RC explicitly because prereleases never update `latest`:
 
 ```bash
-OPENGUI_IMAGE=ghcr.io/akemmanuel/opengui:0.6.0-rc.1 docker compose up -d
+OPENGUI_IMAGE=ghcr.io/akemmanuel/opengui:0.6.0-rc.2 docker compose up -d
 ```
 
 Open `http://127.0.0.1:4839`. The first browser creates the Host owner Account. The compose file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opengui",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0-rc.2",
   "private": false,
   "description": "OpenGUI - first-party coding agent for desktop and web",
   "homepage": "https://github.com/akemmanuel/OpenGUI",
@@ -134,7 +134,8 @@
     "asarUnpack": [
       "dist-electron/backend.js",
       "dist-electron/backend.js.map",
-      "dist-electron/package.json"
+      "dist-electron/package.json",
+      "dist-electron/*.wasm"
     ],
     "linux": {
       "target": [

--- a/scripts/electron-package-metadata.test.ts
+++ b/scripts/electron-package-metadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
+import packageJson from "../package.json" with { type: "json" };
 import { createElectronRuntimePackage, packageIdForImport } from "./electron-package-metadata";
 
 describe("Electron package metadata", () => {
@@ -28,5 +29,9 @@ describe("Electron package metadata", () => {
     ["@opengui/backend/routes", "@opengui/backend"],
   ])("resolves package boundary for %s", (specifier, expected) => {
     expect(packageIdForImport(specifier)).toBe(expected);
+  });
+
+  test("unpacks sidecar WebAssembly assets beside the backend bundle", () => {
+    expect(packageJson.build.asarUnpack).toContain("dist-electron/*.wasm");
   });
 });


### PR DESCRIPTION
## Summary

- unpack Photon WebAssembly beside the packaged Desktop backend sidecar
- add a regression test for the Electron packaging contract
- prepare v0.6.0-rc.2 because rc.1 Desktop packages cannot start the Host sidecar

## Exact failure

`ENOENT: /opt/OpenGUI/resources/app.asar.unpacked/dist-electron/photon_rs_bg.wasm`

## Validation

- [x] regression test failed before the fix and passes after it
- [x] `pnpm run check`
- [x] `pnpm run test` — 197 files / 1,036 tests
- [x] `pnpm run slop-check`
- [x] `pnpm run build`
- [x] local Linux deb built
- [x] deb archive contains `app.asar.unpacked/dist-electron/photon_rs_bg.wasm`