### PR TITLE
fix(host): restore session project moves

### DIFF
--- a/src/features/host-provider/HostProvider.render.test.tsx
+++ b/src/features/host-provider/HostProvider.render.test.tsx
@@ -209,6 +209,26 @@ describe("HostProvider render integration", () => {
 
     act(() => actions.setSessionPinned("session-1", true));
     expect(state.sessionMeta["session-1"]?.pinnedAt).toEqual(expect.any(String));
+    await act(() => actions.moveSessionToProject("session-1", "/other/"));
+    expect(state.sessionMeta["session-1"]).toEqual(
+      expect.objectContaining({
+        sidebarSection: "projects",
+        displayProjectDir: "/other",
+        sidebarMovedAt: expect.any(Number),
+      }),
+    );
+    expect(JSON.parse(persisted.values.get(STORAGE_KEYS.SESSION_META) ?? "{}")).toEqual(
+      expect.objectContaining({
+        "session-1": expect.objectContaining({
+          sidebarSection: "projects",
+          displayProjectDir: "/other",
+        }),
+      }),
+    );
+    await act(() => actions.removeSessionFromProject("session-1"));
+    expect(state.sessionMeta["session-1"]).toEqual(
+      expect.objectContaining({ sidebarSection: "chats", displayProjectDir: null }),
+    );
     await act(() => actions.deleteSession("session-1"));
     expect(host.deleteSession).toHaveBeenCalledWith("session-1");
 

--- a/src/features/host-provider/HostProvider.tsx
+++ b/src/features/host-provider/HostProvider.tsx
@@ -47,7 +47,12 @@ import { getShellWorkspacePolicy } from "@/runtime/shell-policy";
 import { normalizeProjectPath } from "@/lib/path";
 import { defaultEnabledSkillNames, sessionSkillsKey } from "@/lib/session-skills";
 import { findModel } from "@/lib/utils";
-import { makeProjectKey, shouldAutoNameSession } from "@/hooks/agent-session-utils";
+import {
+  createSessionProjectDetachMeta,
+  createSessionProjectMoveMeta,
+  makeProjectKey,
+  shouldAutoNameSession,
+} from "@/hooks/agent-session-utils";
 import { STORAGE_KEYS } from "@/lib/constants";
 import { storageGet, storageSet } from "@/lib/persistence/storage";
 import { connectionsToModelProviders } from "@/lib/models-dev";
@@ -1121,8 +1126,26 @@ function HostProviderBody({
           return next;
         });
       },
-      moveSessionToProject: async () => {},
-      removeSessionFromProject: async () => {},
+      moveSessionToProject: async (sessionId, directory) => {
+        const session = sessions.find((item) => item.id === sessionId);
+        setSessionMeta((current) => {
+          const meta = createSessionProjectMoveMeta(session, current[sessionId], directory);
+          if (!meta) return current;
+          const next = { ...current, [sessionId]: { ...current[sessionId], ...meta } };
+          persistSessionMetaMap(next);
+          return next;
+        });
+      },
+      removeSessionFromProject: async (sessionId) => {
+        const session = sessions.find((item) => item.id === sessionId);
+        setSessionMeta((current) => {
+          const meta = createSessionProjectDetachMeta(session, current[sessionId]);
+          if (!meta) return current;
+          const next = { ...current, [sessionId]: { ...current[sessionId], ...meta } };
+          persistSessionMetaMap(next);
+          return next;
+        });
+      },
       setProjectPinned: (directory, pinned) => {
         const projectKey = makeProjectKey(activeWorkspaceId, directory);
         setProjectMeta((current) => {


### PR DESCRIPTION
## Summary
- restore HostProvider actions for moving sessions between sidebar projects
- persist normalized project presentation metadata without changing the execution directory
- restore removing sessions from projects back to chats
- cover move, persistence, and detach behavior in the HostProvider integration test

## Testing
- `pnpm vp test src/features/host-provider/HostProvider.render.test.tsx`
- `pnpm vp check`
- `pnpm run build`
- manually verified in the rebuilt Electron desktop app